### PR TITLE
Feat/#20 SearchPanel 구현

### DIFF
--- a/src/components/Searching/AutoSearchList.tsx
+++ b/src/components/Searching/AutoSearchList.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import AutoSearch from './AutoSearch';
 import { autoSearchResults } from '../../autoSearchResults';
+import SearchTitle from './SearchTitle';
 
 const AutoSearchList: React.FC = () => {
   const filteredData = autoSearchResults;
 
   return (
     <div className='flex flex-col items-start'>
-      {filteredData.map((data) => (
-        <AutoSearch autoSearchData={data} />
+      <SearchTitle title={'검색 결과'} />
+
+      {filteredData.map((data, i) => (
+        <AutoSearch autoSearchData={data} key={i} />
       ))}
     </div>
   );

--- a/src/components/Searching/RecentSearchList.tsx
+++ b/src/components/Searching/RecentSearchList.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { recentSearchText } from '../../recentSearchResults';
 import RecentSearch from './RecentSearch';
+import SearchTitle from './SearchTitle';
 
 const RecentSearchList: React.FC = () => {
   const getRecentSearchText = recentSearchText;
 
   return (
     <div>
+      <SearchTitle title={'최근 검색어'} />
+
       {getRecentSearchText.map((text, i) => (
         <RecentSearch text={text} key={i} />
       ))}

--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -4,7 +4,7 @@ import SearchBar from './SearchBar';
 const SearchArea: React.FC = () => {
   return (
     <div
-      className='fixed top-0 inset-x-0 z-50
+      className='fixed top-0 inset-x-0 z-100
     flex flex-row items-center justify-start pt-[12px] px-[16px]'>
       <SearchBar />
     </div>

--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -4,12 +4,12 @@ import XButton from '../XButton';
 import useSearchStore from '../../store/searchStore';
 
 const SearchArea: React.FC = () => {
-  const { isFocused } = useSearchStore();
+  const { isFocused, setIsFocused } = useSearchStore();
 
   return (
     <div className='flex flex-row items-center justify-start gap-8 pt-[12px] px-[16px]'>
       <SearchBar />
-      {isFocused && <XButton />}
+      {isFocused && <XButton onClickFunc={() => setIsFocused(false)} />}
     </div>
   );
 };

--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import SearchBar from './SearchBar';
+import XButton from '../XButton';
 
 const SearchArea: React.FC = () => {
   return (
-    <div
-      className='fixed top-0 inset-x-0 z-100
-    flex flex-row items-center justify-start pt-[12px] px-[16px]'>
+    <div className='flex flex-row items-center justify-start gap-8 pt-[12px] px-[16px]'>
       <SearchBar />
+      <XButton />
     </div>
   );
 };

--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import SearchBar from './SearchBar';
 import XButton from '../XButton';
+import useSearchStore from '../../store/searchStore';
 
 const SearchArea: React.FC = () => {
+  const { isFocused } = useSearchStore();
+
   return (
     <div className='flex flex-row items-center justify-start gap-8 pt-[12px] px-[16px]'>
       <SearchBar />
-      <XButton />
+      {isFocused && <XButton />}
     </div>
   );
 };

--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -3,7 +3,9 @@ import SearchBar from './SearchBar';
 
 const SearchArea: React.FC = () => {
   return (
-    <div className='flex flex-row items-center justify-start pt-12 px-16'>
+    <div
+      className='fixed top-0 inset-x-0 z-50
+    flex flex-row items-center justify-start pt-[12px] px-[16px]'>
       <SearchBar />
     </div>
   );

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -1,23 +1,38 @@
 import React from 'react';
-
 import search from '../../assets/search.svg';
 import useSearchStore from '../../store/searchStore';
+import XButtonCircle from '../XButtonCircle';
 
 const SearchBar: React.FC = () => {
-  const { setIsFocused } = useSearchStore();
+  const { isFocused, setIsFocused, inputValue, setInputValue } =
+    useSearchStore();
 
   return (
     <div
-      className='shadow-[0_2px_2px_0_rgba(18,18,18,0.1)] h-[34px] flex-[1_0_0] flex items-center px-[8px] bg-white rounded-[12px]'
+      className={[
+        isFocused
+          ? 'bg-primary-100'
+          : 'bg-white shadow-[0_2px_2px_0_rgba(18,18,18,0.1)]',
+        'h-[34px] flex-[1_0_0] flex items-center px-[8px] rounded-[12px]',
+      ].join(' ')}
       onClick={() => setIsFocused(true)}>
       <div className='flex-1 flex items-center justify-start gap-[4px]'>
         <img className='w-[24px] h-[24px]' src={search} />
-        <div className='flex items-center gap-2'>
-          <div className="flex-1 text-[14px] leading-[100%] tracking-[-0.21px] font-['Pretendard'] text-primary-400">
-            오늘은 어디서 시간을 보내나요?
-          </div>
+        <div className='flex-[1_0_0] flex items-center gap-2'>
+          <input
+            className="focus:outline-none focus:ring-0 resize-none 
+            flex-[1_0_0] text-[14px] leading-[100%] tracking-[-0.21px] font-['Pretendard'] text-primary-900"
+            type='text'
+            value={inputValue}
+            spellCheck={false}
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder='오늘은 어디서 시간을 보내나요?'
+          />
         </div>
       </div>
+      {isFocused && inputValue && (
+        <XButtonCircle onClickFunc={() => setInputValue('')} />
+      )}
     </div>
   );
 };

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -1,11 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import search from '../../assets/search.svg';
 import useSearchStore from '../../store/searchStore';
 import XButtonCircle from '../XButtonCircle';
+import useDebounce from '../../hooks/useDebounce';
 
 const SearchBar: React.FC = () => {
   const { isFocused, setIsFocused, inputValue, setInputValue } =
     useSearchStore();
+
+  const debouncedInput = useDebounce(inputValue, 500);
+
+  // api로 보낼 검색어(inputValue)가 잘 debounced 되었는지 확인
+  useEffect(() => {
+    console.log(debouncedInput);
+  }, [debouncedInput]);
+
+  const onChangeInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
 
   return (
     <div
@@ -25,7 +37,7 @@ const SearchBar: React.FC = () => {
             type='text'
             value={inputValue}
             spellCheck={false}
-            onChange={(e) => setInputValue(e.target.value)}
+            onChange={(e) => onChangeInputValue(e)}
             placeholder='오늘은 어디서 시간을 보내나요?'
           />
         </div>

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
 import search from '../../assets/search.svg';
+import useSearchStore from '../../store/searchStore';
 
 const SearchBar: React.FC = () => {
+  const { setIsFocused } = useSearchStore();
+
   return (
     <div
-      className='shadow-[0_2px_2px_0_rgba(18,18,18,0.1)]
-        h-[34px] flex-[1_0_0] flex items-center px-[8px] bg-white rounded-[12px]'>
+      className='shadow-[0_2px_2px_0_rgba(18,18,18,0.1)] h-[34px] flex-[1_0_0] flex items-center px-[8px] bg-white rounded-[12px]'
+      onClick={() => setIsFocused(true)}>
       <div className='flex-1 flex items-center justify-start gap-[4px]'>
         <img className='w-[24px] h-[24px]' src={search} />
         <div className='flex items-center gap-2'>

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -6,11 +6,13 @@ const SearchBar: React.FC = () => {
   return (
     <div
       className='shadow-[0_2px_2px_0_rgba(18,18,18,0.1)]
-        h-34 flex-[1_0_0] flex items-center px-8 bg-white rounded-[12px]'>
-      <div className='flex-1 flex items-center justify-start gap-4'>
-        <img width='24' height='24' src={search}></img>
-        <div className="flex-1 text-[14px] leading-[100%] tracking-[-0.21px] font-['Pretendard'] text-primary-400">
-          오늘은 어디서 시간을 보내나요?
+        h-[34px] flex-[1_0_0] flex items-center px-[8px] bg-white rounded-[12px]'>
+      <div className='flex-1 flex items-center justify-start gap-[4px]'>
+        <img className='w-[24px] h-[24px]' src={search} />
+        <div className='flex items-center gap-2'>
+          <div className="flex-1 text-[14px] leading-[100%] tracking-[-0.21px] font-['Pretendard'] text-primary-400">
+            오늘은 어디서 시간을 보내나요?
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Searching/SearchPanel.tsx
+++ b/src/components/Searching/SearchPanel.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import SearchTitle from './SearchTitle';
 import SearchArea from './SearchArea';
 import RecentSearchList from './RecentSearchList';
+import AutoSearchList from './AutoSearchList';
+import useSearchStore from '../../store/searchStore';
 
 const SearchPanel: React.FC = () => {
+  const { inputValue } = useSearchStore();
+
   return (
     <div className='z-100 min-h-full bg-[#fff]'>
       <SearchArea />
 
-      <SearchTitle title={'최근 검색어'} />
-      <RecentSearchList />
+      {!inputValue && <RecentSearchList />}
+
+      {inputValue && <AutoSearchList />}
     </div>
   );
 };

--- a/src/components/Searching/SearchPanel.tsx
+++ b/src/components/Searching/SearchPanel.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import SearchArea from './SearchArea';
 import RecentSearchList from './RecentSearchList';
 import AutoSearchList from './AutoSearchList';
 import useSearchStore from '../../store/searchStore';
@@ -8,11 +7,8 @@ const SearchPanel: React.FC = () => {
   const { inputValue } = useSearchStore();
 
   return (
-    <div className='z-100 min-h-full bg-[#fff]'>
-      <SearchArea />
-
+    <div className='z-70 min-h-full bg-[#fff] pt-[46px]'>
       {!inputValue && <RecentSearchList />}
-
       {inputValue && <AutoSearchList />}
     </div>
   );

--- a/src/components/Searching/SearchPanel.tsx
+++ b/src/components/Searching/SearchPanel.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SearchTitle from './SearchTitle';
+import SearchArea from './SearchArea';
+import RecentSearchList from './RecentSearchList';
+
+const SearchPanel: React.FC = () => {
+  return (
+    <div className='z-100 min-h-full bg-[#fff]'>
+      <SearchArea />
+
+      <SearchTitle title={'최근 검색어'} />
+      <RecentSearchList />
+    </div>
+  );
+};
+
+export default SearchPanel;

--- a/src/components/XButton.tsx
+++ b/src/components/XButton.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
-
 import xButton from '../assets/xButton.svg';
 
-const XButton: React.FC = () => {
+interface XButtonProps {
+  onClickFunc: () => void;
+}
+
+const XButton: React.FC<XButtonProps> = ({ onClickFunc }) => {
   return (
-    <div className='w-34 h-34 flex p-4 justify-center items-center gap-10 shrink-0 rounded-[12px] bg-primary-100'>
+    <button
+      className='w-34 h-34 flex p-4 justify-center items-center gap-10 shrink-0 rounded-[12px] bg-primary-100'
+      onClick={onClickFunc}>
       <img className='w-24 h-24' src={xButton} alt='xButton' />
-    </div>
+    </button>
   );
 };
 export default XButton;

--- a/src/components/XButtonCircle.tsx
+++ b/src/components/XButtonCircle.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import xButtonCircle from '../assets/xButtonCircle.svg';
+
+interface XButtonCircleProps {
+  onClickFunc: () => void;
+}
+
+const XButtonCircle: React.FC<XButtonCircleProps> = ({ onClickFunc }) => {
+  return (
+    <button className='w-24 h-24' onClick={onClickFunc}>
+      <img className='w-24 h-24' src={xButtonCircle} alt='xButtonCircle' />
+    </button>
+  );
+};
+export default XButtonCircle;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+const useDebounce = <T extends string>(value: T, delay: number = 500): T => {
+  const [debounceValue, setDebounceValue] = useState<T>(
+    () => value.trim() as T
+  );
+
+  useEffect(() => {
+    // useDebounce 훅은 api로 바로 보낼 문자열을 반환하기 때문에 자체적으로 trim을 수행하도록 한다.
+    const trimmed = value.trim() as T;
+
+    if (!trimmed) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebounceValue(trimmed);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounceValue;
+};
+
+export default useDebounce;

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -10,11 +10,9 @@ const Solmap: React.FC = () => {
 
   return (
     <div className='h-full'>
-      {!isFocused && (
-        <div className='z-50 fixed top-0 inset-x-0'>
-          <SearchArea />
-        </div>
-      )}
+      <div className='z-100 fixed top-0 inset-x-0'>
+        <SearchArea />
+      </div>
 
       {isFocused && <SearchPanel />}
 

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -2,11 +2,21 @@ import React from 'react';
 import BottomSheet from '../components/BottomSheet/BottomSheet';
 import { Outlet } from 'react-router-dom';
 import SearchArea from '../components/Searching/SearchArea';
+import SearchPanel from '../components/Searching/SearchPanel';
+import useSearchStore from '../store/searchStore';
 
 const Solmap: React.FC = () => {
+  const { isFocused } = useSearchStore();
+
   return (
     <div className='h-full'>
-      <SearchArea />
+      {!isFocused && (
+        <div className='z-50 fixed top-0 inset-x-0'>
+          <SearchArea />
+        </div>
+      )}
+
+      {isFocused && <SearchPanel />}
 
       <BottomSheet>
         <Outlet />

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -1,22 +1,18 @@
-import React from 'react'
-import BottomSheet from '../components/BottomSheet/BottomSheet'
+import React from 'react';
+import BottomSheet from '../components/BottomSheet/BottomSheet';
 import { Outlet } from 'react-router-dom';
+import SearchArea from '../components/Searching/SearchArea';
 
-const Solmap:React.FC = () => {
+const Solmap: React.FC = () => {
   return (
-    <div>
-        <div>
-            map
-        </div>
+    <div className='h-full'>
+      <SearchArea />
 
-        <div className='absolute bottom-0'>
-
-        <BottomSheet>
-            <Outlet />
-        </BottomSheet>
-        </div>
+      <BottomSheet>
+        <Outlet />
+      </BottomSheet>
     </div>
-  )
-}
+  );
+};
 
-export default Solmap
+export default Solmap;

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface SearchState {
+  isFocused: boolean;
+  setIsFocused: (focused: boolean) => void;
+}
+
+const useSearchStore = create<SearchState>((set) => ({
+  isFocused: false,
+  setIsFocused: (focused) => set({ isFocused: focused }),
+}));
+
+export default useSearchStore;

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -3,11 +3,15 @@ import { create } from 'zustand';
 interface SearchState {
   isFocused: boolean;
   setIsFocused: (focused: boolean) => void;
+  inputValue: string;
+  setInputValue: (value: string) => void;
 }
 
 const useSearchStore = create<SearchState>((set) => ({
   isFocused: false,
   setIsFocused: (focused) => set({ isFocused: focused }),
+  inputValue: '',
+  setInputValue: (value) => set({ inputValue: value }),
 }));
 
 export default useSearchStore;


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#20 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
- Solmap 페이지에 SearchArea(검색창 영역)을 연결했습니다.
- 피그마의 SearchPanel(Searching 화면)을 구현했습니다.
- zustand 상태관리를 통해서 다음을 구현했습니다.
  - SearchBar(검색창)의 값이 공유되도록 했습니다.
  - SearchArea를 하나로 공유하며 focusing에 따라 SearchPanel을 보이도록 했습니다.
  - SearchBar의 inputValue를 관리하며 값에 따라 '최근 검색어'와 '검색 결과' 컴포넌트가 보이도록 했습니다. 
- 추후 사용자의 입력값을 api 호출에 이용하기 위해 debouncing을 미리 적용하여 콘솔에 출력되도록 구현했습니다. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/cad0d0aa-fc41-4215-9ed2-3d285605f6e1)
![image](https://github.com/user-attachments/assets/ff948cf2-35e1-4130-865f-6fcc679e30f4)
![image](https://github.com/user-attachments/assets/31c2c7fc-ccc6-45c7-92a5-3bfeeeac5cf8)
![image](https://github.com/user-attachments/assets/5f2a5124-ddd8-478c-b52a-698e100b98d1)
![image](https://github.com/user-attachments/assets/ccb1039a-6d38-4b62-9963-e2e7d02a5464)

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- debouncing 텀은 1초로 설정했습니다.
- Solmap의 SearchArea(검색창 영역)은 z-100으로 해두었습니다.  
- SearchPanel(Searching 화면)은 z-70으로 해두었습니다.
- SearchPanel 에  bg 값이 #fff인데 색상코드에 없어서 우선 bg-[#fff]로 작성했습니다. 
- ★ Solmap에서 SearchBar(검색창)을 클릭하면 아래 사진처럼 구조상 BottomNav가 보입니다. 만약 Searching 화면에서 BottomNav가 안 보이도록 해야한다면 BottomNav 컴포넌트 수정이 필요할 것 같습니다. 
![image](https://github.com/user-attachments/assets/839a3caa-c200-4a82-a5b3-682ace0dd2eb)



<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
[검색 기능 구현](https://velog.io/@shagrat/%EC%A2%8C%EC%B6%A9%EC%9A%B0%EB%8F%8C-%EA%B5%AC%EA%B8%80%EB%A7%B5-%EA%B2%80%EC%83%89-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%EA%B8%B0)
