### PR TITLE
[refactor/#34] Searching 화면이 최상단에 위치하도록 수정

### DIFF
--- a/src/components/Searching/SearchPanel.tsx
+++ b/src/components/Searching/SearchPanel.tsx
@@ -7,7 +7,7 @@ const SearchPanel: React.FC = () => {
   const { inputValue } = useSearchStore();
 
   return (
-    <div className='z-70 min-h-full bg-[#fff] pt-[46px]'>
+    <div className='fixed top-0 left-0 w-full z-70 min-h-full bg-[#fff] pt-[46px]'>
       {!inputValue && <RecentSearchList />}
       {inputValue && <AutoSearchList />}
     </div>


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#34 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
Searching 화면이 최상단에 위치하도록 수정했습니다.
z-index 값이 아니라 SearchPanel 컴포넌트에 fixed 값을 부여해서 해결했습니다. 
이미 SearchPanel은 z-70이고,
BottomSheet 자체는 z-150이지만 AppLayout에서 BottomSheet를 감싼 div 태그가 z-50이었습니다.
이 상태에서 z-index가 제대로 적용되지 않은 이유는, BottomSheet는 fixed 였지만 SearchPanel은 fixed가 아니었기 때문이었습니다. 따라서 SearchPanel에 fixed를 추가함으로써 문제를 해결했습니다. 


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/3b5e6ddc-c261-472f-a5f3-f5a98eca46b9)



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

