### PR TITLE
Feat/#42 현위치로 지도 이동 버튼

### DIFF
--- a/src/assets/currentLocation.svg
+++ b/src/assets/currentLocation.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="3" fill="#8691AA"/>
+<circle cx="12" cy="12" r="6" stroke="#8691AA"/>
+<path d="M12 4V5.5M20 12H18.5M12 20V18.5M4 12H5.5" stroke="#8691AA" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/BottomSheet/CurrentLocationButton.tsx
+++ b/src/components/BottomSheet/CurrentLocationButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import currentLocation from '../../assets/currentLocation.svg';
+import { CurrentLocationButtonProps } from '../../interface';
+import { useBottomSheetStore } from '../../store/useBottomSheetStore';
+import { MAX_Y } from '../../constants';
+
+const CurrentLocationButton: React.FC<CurrentLocationButtonProps> = ({
+  handleClick,
+}) => {
+  const { snap } = useBottomSheetStore();
+  const isVisible = snap !== MAX_Y;
+
+  return (
+    <div
+      className='w-30 h-30 bg-white rounded-full border-primary-400 border-[0.1px] flex justify-center items-center right-14 shadow-[0px_0px_2px_0px_rgba(18,18,18,0.10)]'
+      style={{
+        position: 'absolute',
+        bottom: `${(snap || 0) + 6}px`,
+        display: isVisible ? 'flex' : 'none',
+      }}
+      onClick={handleClick}>
+      <img src={currentLocation} alt='currentLocation' className='w-24 h-24' />
+    </div>
+  );
+};
+
+export default CurrentLocationButton;

--- a/src/components/BottomSheet/CurrentLocationButton.tsx
+++ b/src/components/BottomSheet/CurrentLocationButton.tsx
@@ -17,6 +17,7 @@ const CurrentLocationButton: React.FC<CurrentLocationButtonProps> = ({
         position: 'absolute',
         bottom: `${(snap || 0) + 6}px`,
         display: isVisible ? 'flex' : 'none',
+        transition: 'bottom 0.2s ease-in-out',
       }}
       onClick={handleClick}>
       <img src={currentLocation} alt='currentLocation' className='w-24 h-24' />

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,0 +1,3 @@
+export interface CurrentLocationButtonProps {
+  handleClick: () => void;
+}

--- a/src/pages/MapSheet.tsx
+++ b/src/pages/MapSheet.tsx
@@ -69,7 +69,12 @@ const MapSheet: React.FC = () => {
       // 마커 클릭시 지정한 좌표와 줌 레벨을 사용하는 새로운 위치로 지도를 이동
       // 유사한 함수 : setCenter, panTo
       naver.maps.Event.addListener(marker, 'click', () => {
-        mapInstance.current?.morph(marker.getPosition(), 18, {
+        // 마커 위치 중심에서 살짝위로 보정
+        const adjustedPosition = new naver.maps.LatLng(
+          position.lat() - 0.0003,
+          position.lng()
+        );
+        mapInstance.current?.morph(adjustedPosition, 18, {
           duration: 1000,
           easing: 'easeOutCubic',
         });

--- a/src/pages/MapSheet.tsx
+++ b/src/pages/MapSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { places } from '../places';
+import CurrentLocationButton from '../components/BottomSheet/CurrentLocationButton';
 
 const MapSheet: React.FC = () => {
   const mapElement = useRef<HTMLDivElement | null>(null);
@@ -126,12 +127,9 @@ const MapSheet: React.FC = () => {
         표시된 마커로 지도 이동
       </button>
 
-      {/* 임시 버튼: 현재 위치로 */}
-      <button
-        onClick={moveToCurrentLocation}
-        className='absolute right-4 top-1/2 -translate-y-1/2 bg-white shadow px-4 py-2 rounded text-sm z-10'>
-        현재 위치로
-      </button>
+      {/* 현재 위치로 버튼 */}
+      <CurrentLocationButton handleClick={moveToCurrentLocation}/>
+      
     </div>
   );
 };


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#42 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
현위치로 지도 이동 버튼 UI 구현
마커 클릭 시 마커가 지도의 가운데보다 살짝 위로 오게 수정
(둘 다 희정님이 구현해주신 기능 거의 그대로 사용했습니다 😚🙏)

<img width="391" alt="image" src="https://github.com/user-attachments/assets/50386ad0-2c2b-4b16-9bf6-7320ca0cd1ba" />


현위치 아이콘 svg 받아오기
현위치 버튼 바텀시트 따라서 이동하기
바텀시트가 가장 위에 있으면 현위치 버튼 숨기기
<img width="200" alt="image" src="https://github.com/user-attachments/assets/041e4263-3281-4cb0-81b4-32c54c0d034d" /><img width="200" alt="image" src="https://github.com/user-attachments/assets/2f440ef3-c953-488a-aae3-bdcefe725949" />




<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
현위치 svg는 assets 폴더에 currentLocation.svg로 저장해두었습니다.


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

