### PR TITLE
Feat/#47 DetailContent 뒤로가기 XButton 구현

### DIFF
--- a/src/components/BottomSheet/ContentTitle.tsx
+++ b/src/components/BottomSheet/ContentTitle.tsx
@@ -5,6 +5,7 @@ import location from '../../assets/location.svg';
 import clock from '../../assets/clock.svg';
 import share from '../../assets/share.svg';
 import XButton from '../XButton';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface ContentTitleProps {
   place: Place;
@@ -14,6 +15,19 @@ interface ContentTitleProps {
 const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
   const isPreview = property === 'preview';
   const isDetail = property === 'detail';
+
+  const navigate = useNavigate();
+  const from = useLocation().state?.from;
+
+  const handleBack = () => {
+    // 뒤로가기 버튼
+    // search에서 넘어오는 경우 state로 from:search 넘겨줘야 함 (나중에 구현하기)
+    if (from == 'preview') {
+      navigate('/map/list');
+    } else if (from == 'search') {
+      navigate('/map');
+    }
+  };
 
   const buttonStyle = 'w-32 h-32 rounded-lg flex justify-center items-center';
 
@@ -46,7 +60,7 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
             <div className={`${buttonStyle} border border-primary-400`}>
               <img src={share} alt='share' />
             </div>
-            <XButton onClickFunc={()=>{}} detail/>
+            <XButton onClickFunc={handleBack} detail />
           </div>
         )}
       </div>

--- a/src/components/BottomSheet/ContentTitle.tsx
+++ b/src/components/BottomSheet/ContentTitle.tsx
@@ -4,7 +4,7 @@ import { Place } from '../../types';
 import location from '../../assets/location.svg';
 import clock from '../../assets/clock.svg';
 import share from '../../assets/share.svg';
-import xButton from '../../assets/xButton.svg';
+import XButton from '../XButton';
 
 interface ContentTitleProps {
   place: Place;
@@ -46,9 +46,7 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
             <div className={`${buttonStyle} border border-primary-400`}>
               <img src={share} alt='share' />
             </div>
-            <div className={`${buttonStyle} bg-primary-100`}>
-              <img src={xButton} alt='x-button' />
-            </div>
+            <XButton onClickFunc={()=>{}} detail/>
           </div>
         )}
       </div>

--- a/src/components/BottomSheet/Preview/PreviewContent.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContent.tsx
@@ -20,7 +20,7 @@ const PreviewContent:React.FC<PreviewContentProps> = ({place}) => {
   ];
 
   const handleClick = ()=>{
-    navigate('/map/detail');
+    navigate('/map/detail', { state: { from: 'preview' } });
   }
 
   return (

--- a/src/components/XButton.tsx
+++ b/src/components/XButton.tsx
@@ -3,11 +3,10 @@ import xButton from '../assets/xButton.svg';
 
 interface XButtonProps {
   onClickFunc: () => void;
-  detail?:boolean
+  detail?:boolean   // detail props로 안 받아도 된다
 }
 
 const XButton: React.FC<XButtonProps> = ({ onClickFunc, detail }) => {
-  console.log(detail);
   return (
     <button
       className={`w-34 h-34 flex p-4 justify-center items-center gap-10 shrink-0 bg-primary-100 ${detail ?'rounded-lg' : 'rounded-xl'}`}

--- a/src/components/XButton.tsx
+++ b/src/components/XButton.tsx
@@ -3,12 +3,14 @@ import xButton from '../assets/xButton.svg';
 
 interface XButtonProps {
   onClickFunc: () => void;
+  detail?:boolean
 }
 
-const XButton: React.FC<XButtonProps> = ({ onClickFunc }) => {
+const XButton: React.FC<XButtonProps> = ({ onClickFunc, detail }) => {
+  console.log(detail);
   return (
     <button
-      className='w-34 h-34 flex p-4 justify-center items-center gap-10 shrink-0 rounded-[12px] bg-primary-100'
+      className={`w-34 h-34 flex p-4 justify-center items-center gap-10 shrink-0 bg-primary-100 ${detail ?'rounded-lg' : 'rounded-xl'}`}
       onClick={onClickFunc}>
       <img className='w-24 h-24' src={xButton} alt='xButton' />
     </button>


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#47 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->

프리뷰 -> 디테일 : 프리뷰로 이동 /map/list
특정 장소 검색 : 쏠맵 메인화면으로 이동 /map
XButton DetailContent에서도 쓸 수 있도록 수정 (검색창이랑 border-radius가 다름)

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="357" alt="image" src="https://github.com/user-attachments/assets/edb94fc2-b948-4450-b635-e11a7c000c87" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
DetailContent의 ContentTitle 컴포넌트랑 SearchArea에서 쓰이는 XButton의 border-radius가 달라서 수정을 했습니다.
ContentTitle에서 XButton을 쓸 때
detail 을 props로 함께 넘겨주어서 스타일을 다르게 적용시켰습니다.
<img width="355" alt="image" src="https://github.com/user-attachments/assets/b6f3e2fb-7891-4e6e-a1bf-6d32a9bbf222" />
<img width="698" alt="image" src="https://github.com/user-attachments/assets/92f785b2-2166-4381-bc7d-5cced17e5879" />


기존에 XButton을 쓰던 컴포넌트에서는 따로 수정안해도 되게 detail을 Optional Property로 두었습니다!! 원래 쓰던 대로 쓰시면 됩니다
<img width="381" alt="image" src="https://github.com/user-attachments/assets/befd4270-9d8d-4202-8328-4c307f38d17e" />



<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

