### PR TITLE
Refactor/#96 유지보수와 재사용성을 위한 MapSheet.tsx의 함수 분리

### DIFF
--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -4,29 +4,11 @@ import CurrentLocationButton from '../BottomSheet/CurrentLocationButton';
 import { useQuery } from '@tanstack/react-query';
 import { fetchPlacesNearby } from '../../api/mapApi';
 import { useMapStore } from '../../store/mapStore';
-import CafeMarker from '../../assets/category-icons/mapMarker/cafeMarker.svg?url';
-import CultureMarker from '../../assets/category-icons/mapMarker/cultureMarker.svg?url';
-import DrinkMarker from '../../assets/category-icons/mapMarker/drinkMarker.svg?url';
-import EntertainmentMarker from '../../assets/category-icons/mapMarker/entertainmentMarker.svg?url';
-import FoodMarker from '../../assets/category-icons/mapMarker/foodMarker.svg?url';
-import ShopMarker from '../../assets/category-icons/mapMarker/shopMarker.svg?url';
-import WalkMarker from '../../assets/category-icons/mapMarker/walkMarker.svg?url';
-import WorkMarker from '../../assets/category-icons/mapMarker/workMarker.svg?url';
-import { initCluster } from '../../utils/clusterManager';
 import { useShallow } from 'zustand/shallow';
 import { MarkersInfoType } from '../../types';
 import { useMarkersStore } from '../../store/markersStore';
-
-const markerIconMap: Record<string, string> = {
-  food: FoodMarker,
-  cafe: CafeMarker,
-  drink: DrinkMarker,
-  entertainment: EntertainmentMarker,
-  culture: CultureMarker,
-  shop: ShopMarker,
-  walk: WalkMarker,
-  work: WorkMarker,
-};
+import { initCluster } from '../../utils/clusterManager';
+import { IconMarkerMap } from '../../utils/icon';
 
 const MapSheet: React.FC = () => {
   const mapElement = useRef<HTMLDivElement | null>(null);
@@ -151,7 +133,7 @@ const MapSheet: React.FC = () => {
       const marker = new naver.maps.Marker({
         position: position,
         icon: {
-          url: markerIconMap[place.category],
+          url: IconMarkerMap[place.category],
         },
       });
       marker.setMap(mapInstance.current);

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -9,6 +9,7 @@ import { MarkersInfoType } from '../../types';
 import { useMarkersStore } from '../../store/markersStore';
 import { initCluster } from '../../utils/clusterManager';
 import { IconMarkerMap } from '../../utils/icon';
+import { getCurrentBounds, getUserLatLng, initMap } from '../../utils/mapFunc';
 
 const MapSheet: React.FC = () => {
   const mapElement = useRef<HTMLDivElement | null>(null);
@@ -57,7 +58,8 @@ const MapSheet: React.FC = () => {
     if (!mapElement.current) return;
 
     getUserLatLng().then((userLatLng) => {
-      initMap(userLatLng);
+      initMap(mapElement, mapInstance, userLatLng);
+      getCurrentBounds(mapInstance.current, setCurrentLatLng);
     });
   }, []);
 
@@ -74,48 +76,6 @@ const MapSheet: React.FC = () => {
       addMarkers();
     }
   }, [markersInfo]);
-
-  // 사용자의 현재 위치 받아오기 함수
-  const getUserLatLng = async (): Promise<naver.maps.LatLng> => {
-    try {
-      // const position = await new Promise<GeolocationPosition>((res, rej) => {
-      //   navigator.geolocation.getCurrentPosition(res, rej);
-      // });
-      // return new naver.maps.LatLng(position.coords.latitude, position.coords.latitude);
-      // 사용자의 현재 좌표를 서울 지역으로 하드코딩
-      return new naver.maps.LatLng(37.51234, 127.060395);
-    } catch {
-      return new naver.maps.LatLng(37.5666805, 126.9784147); // 기본 좌표 (서울 시청)
-    }
-  };
-
-  const initMap = (center: naver.maps.LatLng) => {
-    if (!mapElement.current) {
-      console.warn('mapElement.current가 null입니다!');
-      return;
-    }
-
-    const MapOptions = {
-      center,
-      zoom: 13,
-      gl: true,
-      customStyleId: import.meta.env.VITE_MAP_STYLE_ID,
-    };
-    const map = new naver.maps.Map(mapElement.current!, MapOptions);
-    mapInstance.current = map;
-
-    getCurrentBounds(mapInstance.current);
-  };
-
-  const getCurrentBounds = (map: naver.maps.Map) => {
-    const bounds: naver.maps.Bounds = map.getBounds();
-    setCurrentLatLng({
-      swY: bounds.minY(),
-      swX: bounds.minX(),
-      neY: bounds.maxY(),
-      neX: bounds.maxX(),
-    });
-  };
 
   const addMarkers = () => {
     if (!mapInstance.current) return;
@@ -200,7 +160,7 @@ const MapSheet: React.FC = () => {
       <div ref={mapElement} className='w-full h-full' />
 
       <button
-        onClick={() => getCurrentBounds(mapInstance.current!)}
+        onClick={() => getCurrentBounds(mapInstance.current!, setCurrentLatLng)}
         className='absolute left-4 top-1/2 -translate-y-1/2 bg-white shadow px-4 py-2 rounded text-sm z-10'>
         getCurrentBounds
       </button>

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -5,11 +5,10 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchPlacesNearby } from '../../api/mapApi';
 import { useMapStore } from '../../store/mapStore';
 import { useShallow } from 'zustand/shallow';
-import { MarkersInfoType } from '../../types';
 import { useMarkersStore } from '../../store/markersStore';
 import { initCluster } from '../../utils/clusterManager';
-import { IconMarkerMap } from '../../utils/icon';
 import { getCurrentBounds, getUserLatLng, initMap } from '../../utils/mapFunc';
+import { addMarkers, deleteMarkers } from '../../utils/markerFunc';
 
 const MapSheet: React.FC = () => {
   const mapElement = useRef<HTMLDivElement | null>(null);
@@ -72,58 +71,10 @@ const MapSheet: React.FC = () => {
   useEffect(() => {
     console.log('mapMarkers :::', markersInfo);
     if (markersInfo.length > 0) {
-      deleteMarkers();
-      addMarkers();
+      deleteMarkers(markersObject, clearMarkersObject);
+      addMarkers(mapInstance, markersInfo, setMarkersObject);
     }
   }, [markersInfo]);
-
-  const addMarkers = () => {
-    if (!mapInstance.current) return;
-
-    const bounds = new naver.maps.LatLngBounds(
-      new naver.maps.LatLng(0, 0),
-      new naver.maps.LatLng(0, 0)
-    );
-    boundsRef.current = bounds;
-
-    markersInfo.map((place: MarkersInfoType) => {
-      const position = new naver.maps.LatLng(place.latitude, place.longitude);
-      bounds.extend(position);
-
-      const marker = new naver.maps.Marker({
-        position: position,
-        icon: {
-          url: IconMarkerMap[place.category],
-        },
-      });
-      marker.setMap(mapInstance.current);
-      setMarkersObject(marker);
-
-      // 마커 클릭시 지정한 좌표와 줌 레벨을 사용하는 새로운 위치로 지도를 이동
-      // 유사한 함수 : setCenter, panTo
-      naver.maps.Event.addListener(marker, 'click', () => {
-        mapInstance.current?.morph(position, 18, {
-          duration: 1000,
-          easing: 'easeOutCubic',
-        });
-      });
-    });
-    // const clustering = initCluster(markedMarkers, mapInstance.current);
-    /*
-     * todo : naver cloud api map forum에서 클러스터별 최상단 마커의 종류에 따른 (클러스터 아이콘) 설정이 가능하다고 답변받을시
-     * clustering.setIcons([clusterIconList[카테고리]])를 사용하여 클러스터 아이콘 지정 구현
-     */
-  };
-
-  const deleteMarkers = () => {
-    if (markersObject.length === 0) return;
-
-    boundsRef.current = null;
-    markersObject.forEach((m) => {
-      m.setMap(null);
-    });
-    clearMarkersObject();
-  };
 
   // 임시 버튼: 표시된 마커 기준으로 지도 이동
   // const moveToMarkers = useCallback(() => {

--- a/src/utils/icon.ts
+++ b/src/utils/icon.ts
@@ -16,17 +16,28 @@ import ShopFill from '../assets/category-icons/shopFill.svg?react';
 import WalkFill from '../assets/category-icons/walkFill.svg?react';
 import WorkFill from '../assets/category-icons/workFill.svg?react';
 
-import FoodBlack from "../assets/category-icons/foodBlack.svg?react"
-import CafeBlack from "../assets/category-icons/cafeBlack.svg?react"
-import DrinkBlack from "../assets/category-icons/DrinkBlack.svg?react"
-import EntertainmentBlack from "../assets/category-icons/entertainmentBlack.svg?react"
-import CultureBlack from "../assets/category-icons/cultureBlack.svg?react"
+import FoodBlack from '../assets/category-icons/foodBlack.svg?react';
+import CafeBlack from '../assets/category-icons/cafeBlack.svg?react';
+import DrinkBlack from '../assets/category-icons/DrinkBlack.svg?react';
+import EntertainmentBlack from '../assets/category-icons/entertainmentBlack.svg?react';
+import CultureBlack from '../assets/category-icons/cultureBlack.svg?react';
 import ShopBlack from '../assets/category-icons/shopBlack.svg?react';
 import WalkBlack from '../assets/category-icons/walkBlack.svg?react';
 import WorkBlack from '../assets/category-icons/workBlack.svg?react';
 
+import CafeMarker from '../assets/category-icons/mapMarker/cafeMarker.svg?url';
+import CultureMarker from '../assets/category-icons/mapMarker/cultureMarker.svg?url';
+import DrinkMarker from '../assets/category-icons/mapMarker/drinkMarker.svg?url';
+import EntertainmentMarker from '../assets/category-icons/mapMarker/entertainmentMarker.svg?url';
+import FoodMarker from '../assets/category-icons/mapMarker/foodMarker.svg?url';
+import ShopMarker from '../assets/category-icons/mapMarker/shopMarker.svg?url';
+import WalkMarker from '../assets/category-icons/mapMarker/walkMarker.svg?url';
+import WorkMarker from '../assets/category-icons/mapMarker/workMarker.svg?url';
 
-export const iconMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
+export const iconMap: Record<
+  string,
+  React.FC<React.SVGProps<SVGSVGElement>>
+> = {
   food: Food,
   cafe: Cafe,
   drink: Drink,
@@ -37,8 +48,10 @@ export const iconMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = 
   work: Work,
 };
 
-
-export const iconFillMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
+export const iconFillMap: Record<
+  string,
+  React.FC<React.SVGProps<SVGSVGElement>>
+> = {
   food: FoodFill,
   cafe: CafeFill,
   drink: DrinkFill,
@@ -49,8 +62,10 @@ export const iconFillMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>
   work: WorkFill,
 };
 
-
-export const iconBlackMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
+export const iconBlackMap: Record<
+  string,
+  React.FC<React.SVGProps<SVGSVGElement>>
+> = {
   food: FoodBlack,
   cafe: CafeBlack,
   drink: DrinkBlack,
@@ -61,3 +76,13 @@ export const iconBlackMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>
   work: WorkBlack,
 };
 
+export const IconMarkerMap: Record<string, string> = {
+  food: FoodMarker,
+  cafe: CafeMarker,
+  drink: DrinkMarker,
+  entertainment: EntertainmentMarker,
+  culture: CultureMarker,
+  shop: ShopMarker,
+  walk: WalkMarker,
+  work: WorkMarker,
+};

--- a/src/utils/mapFunc.ts
+++ b/src/utils/mapFunc.ts
@@ -1,0 +1,48 @@
+import { CurrentLatLng } from '../types';
+
+export const getUserLatLng = async (): Promise<naver.maps.LatLng> => {
+  try {
+    // const position = await new Promise<GeolocationPosition>((res, rej) => {
+    //   navigator.geolocation.getCurrentPosition(res, rej);
+    // });
+    // return new naver.maps.LatLng(position.coords.latitude, position.coords.latitude);
+    // 사용자의 현재 좌표를 서울 지역으로 하드코딩
+    return new naver.maps.LatLng(37.51234, 127.060395);
+  } catch {
+    return new naver.maps.LatLng(37.5666805, 126.9784147); // 기본 좌표 (서울 시청)
+  }
+};
+
+export const getCurrentBounds = (
+  InstanceCurrent: naver.maps.Map | null,
+  callback: (latlng: CurrentLatLng) => void
+) => {
+  const bounds: naver.maps.Bounds = InstanceCurrent!.getBounds();
+  callback({
+    swY: bounds.minY(),
+    swX: bounds.minX(),
+    neY: bounds.maxY(),
+    neX: bounds.maxX(),
+  });
+};
+
+export const initMap = (
+  divRef: React.RefObject<HTMLDivElement | null>,
+  mapRef: React.RefObject<naver.maps.Map | null>,
+  center: naver.maps.LatLng
+) => {
+  if (!divRef.current) {
+    console.warn('ElementCurrent(mapElement.current)가 null입니다!');
+    return;
+  }
+
+  const MapOptions = {
+    center,
+    zoom: 13,
+    gl: true,
+    customStyleId: import.meta.env.VITE_MAP_STYLE_ID,
+  };
+  const map = new naver.maps.Map(divRef.current!, MapOptions);
+  mapRef.current = map;
+  return map;
+};

--- a/src/utils/markerFunc.ts
+++ b/src/utils/markerFunc.ts
@@ -1,0 +1,57 @@
+import { MarkersInfoType } from '../types';
+import { IconMarkerMap } from './icon';
+
+export const addMarkers = (
+  mapRef: React.RefObject<naver.maps.Map | null>,
+  markersInfo: MarkersInfoType[],
+  setMarkersObject: (marker: naver.maps.Marker) => void
+) => {
+  if (!mapRef.current) return;
+
+  // const bounds = new naver.maps.LatLngBounds(
+  //   new naver.maps.LatLng(0, 0),
+  //   new naver.maps.LatLng(0, 0)
+  // );
+  // boundsRef.current = bounds;
+
+  markersInfo.map((place: MarkersInfoType) => {
+    const position = new naver.maps.LatLng(place.latitude, place.longitude);
+    // bounds.extend(position);
+
+    const marker = new naver.maps.Marker({
+      position: position,
+      icon: {
+        url: IconMarkerMap[place.category],
+      },
+    });
+    marker.setMap(mapRef.current);
+    setMarkersObject(marker);
+
+    // 마커 클릭시 지정한 좌표와 줌 레벨을 사용하는 새로운 위치로 지도를 이동
+    // 유사한 함수 : setCenter, panTo
+    naver.maps.Event.addListener(marker, 'click', () => {
+      mapRef.current?.morph(position, 18, {
+        duration: 1000,
+        easing: 'easeOutCubic',
+      });
+    });
+  });
+  // const clustering = initCluster(markedMarkers, mapRef.current);
+  /*
+   * todo : naver cloud api map forum에서 클러스터별 최상단 마커의 종류에 따른 (클러스터 아이콘) 설정이 가능하다고 답변받을시
+   * clustering.setIcons([clusterIconList[카테고리]])를 사용하여 클러스터 아이콘 지정 구현
+   */
+};
+
+export const deleteMarkers = (
+  markersObject: naver.maps.Marker[],
+  clearMarkersObject: () => void
+) => {
+  if (markersObject.length === 0) return;
+
+  // boundsRef.current = null;
+  markersObject.forEach((m) => {
+    m.setMap(null);
+  });
+  clearMarkersObject();
+};


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#96 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
MapSheet.tsx의 과도한 책임 분산 문제를 해결하고, 관심사 분리 및 가독성 향상을 위해 지도 관련 함수와 마커 관련 함수를 별도 파일로 분리하였습니다.

기존에는 모든 로직이 한 파일에 집중되어 있었습니다. 이번 리팩토링을 통해 각 기능이 명확히 구분되며, 코드 관리가 용이해졌습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
각 기능을 별도 파일로 분리하여 MapSheet.tsx의 과도한 책임을 분산시켰습니다.
다만, 함수 분리로 인해 여러 인자를 전달해야 하는 번거로움이 생겼고,
해당 함수들이 실제로 다른 파일에서 재사용될 가능성은 낮아 보입니다.

👉 이런 경우에도 기능 분리와 모듈화가 적절한 방식인지에 대한 의견이 궁금해요! 
구조적인 관점에서 유지보수성/가독성 개선이 더 우선인지, 아니면 실제 재사용 가능성을 기준으로 판단해야 하는지 리뷰 부탁드립니다 :) 

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

