### PR TITLE
[feat/#85] '이 지역에서 검색' 버튼 UI 구현 및 기능 연결

### DIFF
--- a/src/assets/compass.svg
+++ b/src/assets/compass.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="6.5" stroke="#434A61"/>
+<path d="M6.93921 6.93935L10.8286 5.17188L9.06053 9.06067L5.17176 10.8287L6.93921 6.93935Z" stroke="#434A61" stroke-linejoin="round"/>
+</svg>

--- a/src/components/BottomSheet/ReloadMarkerButton.tsx
+++ b/src/components/BottomSheet/ReloadMarkerButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Compass from '../../assets/compass.svg?react';
+import { ReloadMarkerButtonProps } from '../../interface';
+import { MAX_Y } from '../../constants';
+import { useBottomSheetStore } from '../../store/bottomSheetStore';
+
+const ReloadMarkerButton: React.FC<ReloadMarkerButtonProps> = ({
+  handleClick,
+}) => {
+  const { snap } = useBottomSheetStore();
+  const isVisible = snap !== MAX_Y;
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        position: 'absolute',
+        bottom: `${(snap || 0) + 6}px`,
+        display: isVisible ? 'flex' : 'none',
+        alignItems: 'center',
+        justifyContent: 'center',
+        transition: 'bottom 0.2s ease-in-out',
+      }}>
+      <div
+        className='inline-flex h-32 py-16 pr-12 pl-8 items-center shrink-0 rounded-[100px] bg-primary-50 shadow-[0_1_2_0_rgba(18,18,18,0.1)] '
+        onClick={handleClick}>
+        <div className='flex w-24 h-24 p-4 justify-center items-center'>
+          <Compass />
+        </div>
+        <p className='text-primary-700 text-xs font-medium leading-[120%] tracking-[-0.18px]'>
+          이 지역에서 검색
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ReloadMarkerButton;

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -9,6 +9,7 @@ import { useMarkersStore } from '../../store/markersStore';
 import { initCluster } from '../../utils/clusterManager';
 import { getCurrentBounds, getUserLatLng, initMap } from '../../utils/mapFunc';
 import { addMarkers, deleteMarkers } from '../../utils/markerFunc';
+import ReloadMarkerButton from '../BottomSheet/ReloadMarkerButton';
 
 const MapSheet: React.FC = () => {
   const mapElement = useRef<HTMLDivElement | null>(null);
@@ -110,18 +111,18 @@ const MapSheet: React.FC = () => {
     <div className='relative w-dvw h-dvh'>
       <div ref={mapElement} className='w-full h-full' />
 
-      <button
-        onClick={() => getCurrentBounds(mapInstance.current!, setCurrentLatLng)}
-        className='absolute left-4 top-1/2 -translate-y-1/2 bg-white shadow px-4 py-2 rounded text-sm z-10'>
-        getCurrentBounds
-      </button>
-
       {/* 임시 버튼: 표시된 마커 기준으로 지도 이동*/}
       {/* <button
         onClick={moveToMarkers}
         className='absolute left-4 top-1/2 -translate-y-1/2 bg-white shadow px-4 py-2 rounded text-sm z-10'>
         표시된 마커로 지도 이동
       </button> */}
+
+      <ReloadMarkerButton
+        handleClick={() =>
+          getCurrentBounds(mapInstance.current!, setCurrentLatLng)
+        }
+      />
 
       <CurrentLocationButton handleClick={moveToCurrentLocation} />
     </div>

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,29 +1,33 @@
-import { Category, SollectPhotoType } from "./types";
+import { Category, SollectPhotoType } from './types';
+
+export interface ReloadMarkerButtonProps {
+  handleClick: () => void;
+}
 
 export interface CurrentLocationButtonProps {
   handleClick: () => void;
 }
 
-export interface TitleHeaderProps{
-  title:string;
-  onClick():void;
+export interface TitleHeaderProps {
+  title: string;
+  onClick(): void;
 }
 
-export interface SollectPhotoProps{
-  sollect:SollectPhotoType;
+export interface SollectPhotoProps {
+  sollect: SollectPhotoType;
 }
 
-export interface SollectChipProps{
-  category:Category,
+export interface SollectChipProps {
+  category: Category;
 }
 
-export interface SollectListProps{
-  sollects:SollectPhotoType[];
-  horizontal?:boolean;
-  customStyle?:string;
+export interface SollectListProps {
+  sollects: SollectPhotoType[];
+  horizontal?: boolean;
+  customStyle?: string;
 }
 
-export interface SollectGroupProps{
-  sollects:SollectPhotoType[];
-  title:string;
+export interface SollectGroupProps {
+  sollects: SollectPhotoType[];
+  title: string;
 }


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#85 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
사용자가 현재 보고 있는 지도 영역에서 장소를 검색할 수 있도록
'이 지역에서 검색' 버튼을 구현하고, 클릭 시 getCurrentBounds를 호출하여
지도 중심 좌표를 기반으로 fetchPlacesNearby API를 실행하도록 기능 연결함.
BottomSheet 컴포넌트와 함께 버튼을 위치시키고 싶었으나 함수 호출시 전달해야할 인자 때문에 MapSheet 컴포넌트에 위치하게 됨. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/c746800f-419e-4751-8687-86026771af54)
![image](https://github.com/user-attachments/assets/5895426a-4a42-4a27-95d3-46651cec7ec2)


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

