### PR TITLE
[Feat/#112] 쏠맵 최근 검색 및 엔터 동작 추가 구현 

### DIFF
--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -6,12 +6,18 @@ export const ENDPOINT = {
   // solmap
   SOLMAP_MARKERS: '/api/solmap/markers',
   RELATED_SEARCH: '/api/solmap/search/related',
+
+  // solmap + sollect
   RECENT_SEARCH: {
     GET: (mode: string) => `/api/${mode}/search/recent`,
     POST: (mode: string) => `/api/${mode}/search/recent`,
     DELETE: (mode: string, keyword: string) =>
       `/api/${mode}/search/recent/${encodeURIComponent(keyword)}`,
   },
+
+  // sollect
   SOLLECT_SEARCH: '/api/sollect/search',
+
+  // solmark
   SOLMARK_SOLLECT: '/api/solmark/sollect',
 };

--- a/src/components/Searching/RecentSearchList.tsx
+++ b/src/components/Searching/RecentSearchList.tsx
@@ -7,7 +7,7 @@ import { getRecentSearchWords } from '../../api/searchApi';
 const RecentSearchList: React.FC = () => {
   const mode = window.location.pathname.includes('/sollect/search')
     ? 'sollect'
-    : 'map';
+    : 'solmap';
 
   const { data } = useQuery({
     queryKey: ['recentSearchWords'],

--- a/src/components/Searching/RelatedSearchList.tsx
+++ b/src/components/Searching/RelatedSearchList.tsx
@@ -22,6 +22,7 @@ const RelatedSearchList: React.FC = () => {
   const { data, isSuccess, error } = useQuery({
     queryKey: ['RSList', debouncedInput],
     queryFn: () => {
+      // todo : 사용자의 실시간 좌표로 가져오기
       return getRelatedSearchWords(debouncedInput, 37.51234, 127.060395);
     },
     enabled: debouncedInput !== '',
@@ -41,8 +42,8 @@ const RelatedSearchList: React.FC = () => {
     <div className='flex flex-col items-start'>
       <SearchTitle title={'검색 결과'} />
 
-      {relatedSearchList.map((data) => (
-        <RelatedSearch relatedSearchWord={data} key={data.id} />
+      {relatedSearchList?.map((data) => (
+        <RelatedSearch relatedSearchWord={data} key={data.id || data.name} />
       ))}
     </div>
   );

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -20,7 +20,7 @@ const SearchBar: React.FC = () => {
 
   const mode = window.location.pathname.includes('/sollect/search')
     ? 'sollect'
-    : 'map';
+    : 'solmap';
 
   const changeInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -10,13 +10,15 @@ import { useNavigate } from 'react-router-dom';
 const SearchBar: React.FC = () => {
   const navigate = useNavigate();
 
-  const { inputValue, setInputValue, setRelatedSearchList } = useSearchStore(
-    useShallow((state) => ({
-      inputValue: state.inputValue,
-      setInputValue: state.setInputValue,
-      setRelatedSearchList: state.setRelatedSearchList,
-    }))
-  );
+  const { inputValue, setInputValue, relatedSearchList, setRelatedSearchList } =
+    useSearchStore(
+      useShallow((state) => ({
+        inputValue: state.inputValue,
+        setInputValue: state.setInputValue,
+        relatedSearchList: state.relatedSearchList,
+        setRelatedSearchList: state.setRelatedSearchList,
+      }))
+    );
 
   const mode = window.location.pathname.includes('/sollect/search')
     ? 'sollect'
@@ -27,14 +29,18 @@ const SearchBar: React.FC = () => {
   };
 
   const handleEnter = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      if (mode === 'sollect') {
-        navigate('/sollect/search/result');
-      } else if (mode === 'solmap') {
+    if (e.key !== 'Enter') return;
+
+    if (e.key === 'Enter' && mode === 'sollect') {
+      navigate('/sollect/search/result');
+    } else if (e.key === 'Enter' && mode === 'solmap') {
+      if (relatedSearchList.length > 0) {
         navigate('/map/list');
+      } else {
+        navigate('/map/not-found');
       }
-      postRecentSearchWord(inputValue, mode);
     }
+    postRecentSearchWord(inputValue, mode);
   };
 
   const clickXButtonCircle = () => {

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -28,7 +28,11 @@ const SearchBar: React.FC = () => {
 
   const handleEnter = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      navigate('/sollect/search/result');
+      if (mode === 'sollect') {
+        navigate('/sollect/search/result');
+      } else if (mode === 'solmap') {
+        navigate('/map/list');
+      }
       postRecentSearchWord(inputValue, mode);
     }
   };

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -28,7 +28,10 @@ const AppRouter = () => {
         <Route path='/' element={<AppLayout />}>
           <Route path='sollect' element={<SollectPage />} />
           <Route path='sollect/search' element={<SearchPage />} />
-          <Route path='sollect/search/result' element={<SollectSearchResultPage />} />
+          <Route
+            path='sollect/search/result'
+            element={<SollectSearchResultPage />}
+          />
 
           <Route path='map' element={<Solmap />}>
             <Route index element={<CategoryButtonList />} />
@@ -38,6 +41,7 @@ const AppRouter = () => {
             <Route path='reviews/:placeId' element={<ReviewsPage />} />
             <Route path='review-write/:placeId' element={<ReviewWrite />} />
           </Route>
+
           <Route path='map/search' element={<SearchPage />} />
           <Route path='mark' element={<></>} />
           <Route path='profile' element={<Profile />} />


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#112 #114 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
쏠맵(SoMap)의 최근 검색어 및 검색 실행(엔터 동작) 관련 오류를 수정했습니다.
쏠렉트(Solect)와 쏠맵의 pathname에 따라 검색 동작을 분기처리하도록 되어 있었으나,
내부적으로 mode 값이 "map"으로 잘못 지정되어 쏠맵에서 403 에러가 발생하는 문제가 있었습니다.

- mode 값을 "map" ➝ "solmap" 으로 올바르게 수정하여 쏠맵 환경에서도 403 오류가 발생하지 않도록 처리
- SearchBar, RecentSearchList, RecentSearch 등 관련 컴포넌트의 분기처리는 잘 되어 있었으며, 내부 상태값만 수정
- 쏠맵에서 검색어 입력 후 Enter 시:
  연관 검색어가 존재하면 → 쏠맵의 프리뷰 화면으로 이동
  연관 검색어가 없으면 → "검색 결과 없음" 화면으로 이동하도록 설정

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/c3250b0f-1e21-421e-85e1-83c48ed78e78)
쏠맵의 엔터 동작 분기 처리 

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

