### PR TITLE
[feat/#114] 사용자의 실시간 좌표로 getRelatedSearchWords 호출

### DIFF
--- a/src/components/Searching/RelatedSearchList.tsx
+++ b/src/components/Searching/RelatedSearchList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import RelatedSearch from './RelatedSearch';
 import SearchTitle from './SearchTitle';
 import { useSearchStore } from '../../store/searchStore';
@@ -22,11 +22,14 @@ const RelatedSearchList: React.FC = () => {
   const { data, isSuccess, error } = useQuery({
     queryKey: ['RSList', debouncedInput],
     queryFn: () => {
-      // todo : 사용자의 실시간 좌표로 가져오기
-      return getRelatedSearchWords(debouncedInput, 37.51234, 127.060395);
+      return getRelatedSearchWords(debouncedInput, latlng.lat, latlng.lng);
     },
     enabled: debouncedInput !== '',
   });
+
+  if (error) {
+    console.log('RSList error :::', error);
+  }
 
   useEffect(() => {
     if (isSuccess) {
@@ -34,9 +37,21 @@ const RelatedSearchList: React.FC = () => {
     }
   }, [isSuccess, data, setRelatedSearchList]);
 
-  if (error) {
-    console.log('RSList error :::', error);
-  }
+  // 사용자가 위치정보를 허용하지 않을 시 좌표가 0,0으로 설정됨.
+  const [latlng, setLatlng] = useState({ lat: 0, lng: 0 });
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (res) => {
+          setLatlng({ lat: res.coords.latitude, lng: res.coords.longitude });
+        },
+        (err) => {
+          console.error(err);
+        }
+      );
+    }
+  }, []);
 
   return (
     <div className='flex flex-col items-start'>


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#114 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
사용자의 실시간 좌표로 getRelatedSearchWords를 호출하도록 했습니다.
단, 사용자가 위치정보를 허용하지 않을 시 좌표가 0,0으로 설정됩니다.
![image](https://github.com/user-attachments/assets/e3925295-ed1a-4d28-a36f-f277d9271c30)


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/795ab122-8e74-4fc2-8097-2dd5c7ad84c5)
위 사진) 실시간 좌표 적용 전
<br><br>
![image](https://github.com/user-attachments/assets/29da183c-f59a-49a6-a893-a76bba1d966c)
위 사진) 실시간 좌표 적용 후

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

