### PR TITLE
Feat/#123 쏠렉트 검색 무한 스크롤 구현

### DIFF
--- a/src/api/sollectApi.ts
+++ b/src/api/sollectApi.ts
@@ -21,7 +21,6 @@ export const searchSollect = async (
 
   try {
     const res = await publicAxios.get(ENDPOINT.SOLLECT_SEARCH, { params });
-    console.log(res.data.data);
     return res.data.data.contents;
   } catch (e) {
     console.log(e);

--- a/src/components/Sollect/PopularSollectPhoto.tsx
+++ b/src/components/Sollect/PopularSollectPhoto.tsx
@@ -34,8 +34,7 @@ const PopularSollectPhoto: React.FC<PopularSollectProps> = ({
       <div className='p-24 z-1 text-white'>
         <h1 className='text-3xl font-bold pb-16'>{sollect.title}</h1>
         <div className='flex justify-between'>
-          {/* 나중에 장소명으로 변경하기 */}
-          <span className='text-xs'>{sollect.title}</span>
+          <span className='text-xs'>{sollect.placeName}</span>
           <span className='text-xs flex items-center'>
             <img src={locationWhite} alt='location' className='h-16 w-16' />
             {sollect.district}, {sollect.neighborhood}

--- a/src/components/Sollect/SollectChip/SollectChipList.tsx
+++ b/src/components/Sollect/SollectChip/SollectChipList.tsx
@@ -6,7 +6,7 @@ const SollectChipList = () => {
   return (
     <div className='flex p-16 pt-4 gap-10 overflow-x-scroll border-b-1 border-grayScale-100'>
       {categories.map((category) => {
-        return <SollectChip category={category} />;
+        return <SollectChip category={category} key={category.id}/>;
       })}
     </div>
   );

--- a/src/components/Sollect/SollectList.tsx
+++ b/src/components/Sollect/SollectList.tsx
@@ -8,14 +8,16 @@ const SollectList: React.FC<SollectListProps> = ({ horizontal, sollects, customS
   if (horizontal) {
     style += ' px-16 flex overflow-x-scroll flex-row gap-4 overflow-y-auto';
   } else {
-    style += ' flex flex-wrap gap-12 justify-center overflow-y-auto';
+    style += ' gap-12 overflow-y-auto grid grid-cols-2';
   }
 
   return (
-    <div className={style}>
-      {sollects.map((sollect) => {
-        return <SollectPhoto sollect={sollect} key={sollect.sollectId} />;
-      })}
+    <div className='flex justify-center'>
+      <div className={style}>
+        {sollects.map((sollect) => {
+          return <SollectPhoto sollect={sollect} key={sollect.sollectId} />;
+        })}
+      </div>
     </div>
   );
 };

--- a/src/components/Sollect/SollectList.tsx
+++ b/src/components/Sollect/SollectList.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import SollectPhoto from './SollectPhoto';
 import { SollectListProps } from '../../interface';
 
-const SollectList: React.FC<SollectListProps> = ({ horizontal, sollects, customStyle }) => {
+const SollectList: React.FC<SollectListProps> = ({ horizontal, sollects, customStyle}) => {
   let style = customStyle;
+  
   if (horizontal) {
-    style += ' px-16 flex overflow-x-scroll flex-row gap-4';
+    style += ' px-16 flex overflow-x-scroll flex-row gap-4 overflow-y-auto';
   } else {
-    style += ' flex flex-wrap gap-12 justify-center';
+    style += ' flex flex-wrap gap-12 justify-center overflow-y-auto';
   }
+
   return (
     <div className={style}>
       {sollects.map((sollect) => {

--- a/src/components/Sollect/SollectNoResult.tsx
+++ b/src/components/Sollect/SollectNoResult.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import SollectList from './SollectList';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSollects } from '../../api/sollectApi';

--- a/src/hooks/useInfiniteScrollQuery.ts
+++ b/src/hooks/useInfiniteScrollQuery.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+interface useInfiniteScrollOptions {
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage: boolean;
+  rootMargin?: string;
+};
+
+
+// 스크롤을 끝까지 했는지 감지 -> 다음 페이지 자동 Fetch 도와줌
+export const useScrollSentinel = ({
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
+  rootMargin = '100px',
+}: useInfiniteScrollOptions) => {
+  // 감시할 요소
+  // sentinelRef가 화면에 보인다 = 끝까지 스크롤 했다
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          // sentinel이 화면에 보임 & 다음 페이지 있음 -> 다음 페이지 fetch
+          fetchNextPage();
+        }
+      },
+      {
+        root: null,
+        rootMargin: rootMargin,
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinelRef.current);
+
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return sentinelRef;
+};

--- a/src/pages/SollectSearchResultPage.tsx
+++ b/src/pages/SollectSearchResultPage.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import SollectGNB from '../components/Sollect/SollectGNB';
 import SollectChipList from '../components/Sollect/SollectChip/SollectChipList';
 import SollectList from '../components/Sollect/SollectList';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { fetchSollects, searchSollect } from '../api/sollectApi';
 import SollectNoResult from '../components/Sollect/SollectNoResult';
 import { useSearchStore } from '../store/searchStore';
@@ -10,24 +10,68 @@ import { useSollectStore } from '../store/sollectStore';
 
 const SollectSearchResultPage = () => {
   const { inputValue } = useSearchStore();
-  const {selectedCategory, clearCategory} = useSollectStore();
-  const [cursorId, setCursorId] = useState();
+  const { selectedCategory, clearCategory } = useSollectStore();
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
-  const { data } = useQuery({
-    queryKey: ['searchSollect', inputValue, selectedCategory, cursorId],
-    queryFn: () => searchSollect(inputValue, selectedCategory, undefined, cursorId),
-  });
+  // const { data } = useQuery({
+  //   queryKey: ['searchSollect', inputValue, selectedCategory, cursorId],
+  //   queryFn: () => searchSollect(inputValue, selectedCategory, undefined, cursorId),
+  // });
+
+  // 무한 스크롤
+  // pageParam이 cursorId 역할을 한다. 초기값은 undefined
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ['searchSollect', inputValue, selectedCategory],
+      queryFn: ({ pageParam = undefined }) =>
+        searchSollect(inputValue, selectedCategory, undefined, pageParam),
+      getNextPageParam: (lastPage) => {
+        if (!lastPage || lastPage.length === 0) return undefined;
+        // 마지막 쏠렉트의 id를 nextPage(cursorId)로 설정
+        return lastPage[lastPage.length - 1].sollectId;
+      },
+      initialPageParam: undefined,
+    });
+
+  // 데이터 합침
+  const sollects = data ? data.pages.flat() : [];
+
+  // 스크롤 끝까지 했는지 감지하기
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      {
+        root: null,
+        rootMargin: '100px',
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinelRef.current);
+
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   return (
     <div>
       <div className='z-10 w-full bg-white fixed'>
         <SollectGNB />
-        {data && data.length !== 0 && <SollectChipList />}
+        {sollects && sollects.length !== 0 && <SollectChipList />}
       </div>
 
-      {data && data.length !== 0 ? (
+      {sollects && sollects.length !== 0 ? (
         <div className='pt-133 pb-24'>
-          <SollectList sollects={data ? data : []} />
+          <SollectList sollects={sollects ? sollects : []} />
+          <div ref={sentinelRef} style={{ height: '1px' }} />
+          {isFetchingNextPage && (
+            <div className='text-center py-4'>로딩 중...</div>
+          )}
         </div>
       ) : (
         <SollectNoResult />

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,4 +73,5 @@ export type SollectPhotoType = {
   district:string;
   neighborhood:string;
   isMarked:boolean;
+  placeName:string;
 };


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#123 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
무한 스크롤할 때 바닥까지 스크롤했는지 검사하는 useScrollSentinel hook 구현
쏠렉트 검색할 때 홀수개면 중앙에 오는 오류 수정

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="407" alt="image" src="https://github.com/user-attachments/assets/a3305d0b-ce0b-4cd0-8c8b-b3aa554909ee" />



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
스크롤을 끝까지 했는지 감지하는 hook을 만들어 두었습니다. (hook > useInfiniteScrollQuery.ts)
sentinelRef Div가 화면 안에 들어오면 자동으로 다음 페이지를 fetch하도록 했어요

무한 스크롤이 필요한 장소 리스트, 리뷰 리스트에서도
react-query의 useInfiniteQuery를 사용해 `data`, `fetchNextPage`, `hasNextPage`, `isFetchingNextPage`를 받아오면 됩니다.
(SollectSearchResultPage.tsx 참고)



<img width="836" alt="image" src="https://github.com/user-attachments/assets/a69d8d17-0abe-4b7e-a2a2-9b4e95371d7f" />




<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

