### PR TITLE
Feat/#133 solmap api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.71.1",
         "@tanstack/react-query-devtools": "^5.71.1",
         "axios": "^1.8.4",
+        "qs": "^6.14.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.4.1",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/navermaps": "^3.7.9",
+        "@types/qs": "^6.14.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react-swc": "^3.8.0",
@@ -2090,6 +2092,13 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
@@ -2484,6 +2493,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3971,6 +3996,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4170,6 +4207,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -4384,6 +4436,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/snake-case": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.71.1",
     "@tanstack/react-query-devtools": "^5.71.1",
     "axios": "^1.8.4",
+    "qs": "^6.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.4.1",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@types/navermaps": "^3.7.9",
+    "@types/qs": "^6.14.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react-swc": "^3.8.0",

--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,7 +1,8 @@
+import qs from 'qs';
 import { publicAxios } from './axios';
 import { ENDPOINT } from './urls';
 
-export const getDisplayMarkers = async (
+export const getMarkersByDisplay = async (
   swX: number,
   swY: number,
   neX: number,
@@ -21,8 +22,18 @@ export const getDisplayMarkers = async (
   return response.data.data;
 };
 
-export const getRegionMarkers = async (regionName: string) => {
+export const getMarkersByRegion = async (regionName: string) => {
   const res = await publicAxios.get(ENDPOINT.SOLMAP_MARKERS_REGION(regionName));
+
+  return res.data.data;
+};
+
+export const getMarkersByIdList = async (ids: number[]) => {
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_MARKERS_ID_LIST, {
+    params: { ids },
+    paramsSerializer: (params) =>
+      qs.stringify(params, { arrayFormat: 'repeat' }),
+  });
 
   return res.data.data;
 };

--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -3,19 +3,19 @@ import { publicAxios } from './axios';
 import { ENDPOINT } from './urls';
 
 export const getMarkersByDisplay = async (
-  swX: number,
-  swY: number,
-  neX: number,
-  neY: number,
+  swLat: number, // swY - min
+  swLng: number, // swX
+  neLat: number, // neY - max
+  neLng: number, // neX
   category?: string
 ) => {
   const response = await publicAxios.get(ENDPOINT.SOLMAP_MARKERS, {
     params: {
-      swLng: swX,
-      swLat: swY,
-      neLng: neX,
-      neLat: neY,
-      category: category,
+      swLat,
+      swLng,
+      neLat,
+      neLng,
+      category,
     },
   });
 

--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -22,7 +22,7 @@ export const getDisplayMarkers = async (
 };
 
 export const getRegionMarkers = async (regionName: string) => {
-  const res = await publicAxios.get(ENDPOINT.SOLMAP_REGION_MARKERS(regionName));
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_MARKERS_REGION(regionName));
 
   return res.data.data;
 };

--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -18,7 +18,11 @@ export const getDisplayMarkers = async (
     },
   });
 
-  console.log('response.data.data :::', response.data.data);
-
   return response.data.data;
+};
+
+export const getRegionMarkers = async (regionName: string) => {
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_REGION_MARKERS(regionName));
+
+  return res.data.data;
 };

--- a/src/api/placeApi.ts
+++ b/src/api/placeApi.ts
@@ -1,8 +1,16 @@
 import { Place } from '../types';
+import { publicAxios } from './axios';
+import { ENDPOINT } from './urls';
 
 export const fetchPlaces = async () => {
   await new Promise((res) => setTimeout(res, 500));
   return mockPlaces;
+};
+
+export const getPlaceDetail = async (id: number) => {
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_DETAIL + id);
+
+  return res.data.data;
 };
 
 export const fetchPlaceById = async (id: number) => {
@@ -25,13 +33,13 @@ const mockPlaces: Place[] = [
       { id: 'cozy', text: '편안한' },
     ],
     hours: [
-      { day: 0, startTime: "10:00", endTime: "20:30" },
-      { day: 1, startTime: "10:00", endTime: "20:30" },
-      { day: 2, startTime: "10:00", endTime: "20:30" },
-      { day: 3, startTime: "10:00", endTime: "20:30" },
-      { day: 4, startTime: "10:00", endTime: "20:30" },
-      { day: 5, startTime: "10:00", endTime: "20:30" },
-      { day: 6, startTime: "10:00", endTime: "17:00" },
+      { day: 0, startTime: '10:00', endTime: '20:30' },
+      { day: 1, startTime: '10:00', endTime: '20:30' },
+      { day: 2, startTime: '10:00', endTime: '20:30' },
+      { day: 3, startTime: '10:00', endTime: '20:30' },
+      { day: 4, startTime: '10:00', endTime: '20:30' },
+      { day: 5, startTime: '10:00', endTime: '20:30' },
+      { day: 6, startTime: '10:00', endTime: '17:00' },
     ],
   },
 
@@ -49,13 +57,13 @@ const mockPlaces: Place[] = [
       { id: 'cozy', text: '편안한' },
     ],
     hours: [
-      { day: 0, startTime: "10:00", endTime: "20:30" },
-      { day: 1, startTime: "10:00", endTime: "20:30" },
-      { day: 2, startTime: "10:00", endTime: "20:30" },
-      { day: 3, startTime: "10:00", endTime: "20:30" },
-      { day: 4, startTime: "10:00", endTime: "20:30" },
-      { day: 5, startTime: "10:00", endTime: "20:30" },
-      { day: 6, startTime: "10:00", endTime: "17:00" },
+      { day: 0, startTime: '10:00', endTime: '20:30' },
+      { day: 1, startTime: '10:00', endTime: '20:30' },
+      { day: 2, startTime: '10:00', endTime: '20:30' },
+      { day: 3, startTime: '10:00', endTime: '20:30' },
+      { day: 4, startTime: '10:00', endTime: '20:30' },
+      { day: 5, startTime: '10:00', endTime: '20:30' },
+      { day: 6, startTime: '10:00', endTime: '17:00' },
     ],
   },
   {
@@ -72,13 +80,13 @@ const mockPlaces: Place[] = [
       { id: 'hip', text: '힙한' },
     ],
     hours: [
-      { day: 0, startTime: "10:00", endTime: "20:30" },
-      { day: 1, startTime: "10:00", endTime: "20:30" },
-      { day: 2, startTime: "10:00", endTime: "20:30" },
-      { day: 3, startTime: "10:00", endTime: "20:30" },
-      { day: 4, startTime: "10:00", endTime: "20:30" },
-      { day: 5, startTime: "10:00", endTime: "20:30" },
-      { day: 6, startTime: "10:00", endTime: "17:00" },
+      { day: 0, startTime: '10:00', endTime: '20:30' },
+      { day: 1, startTime: '10:00', endTime: '20:30' },
+      { day: 2, startTime: '10:00', endTime: '20:30' },
+      { day: 3, startTime: '10:00', endTime: '20:30' },
+      { day: 4, startTime: '10:00', endTime: '20:30' },
+      { day: 5, startTime: '10:00', endTime: '20:30' },
+      { day: 6, startTime: '10:00', endTime: '17:00' },
     ],
   },
 
@@ -96,13 +104,13 @@ const mockPlaces: Place[] = [
       { id: 'hip', text: '힙한' },
     ],
     hours: [
-      { day: 0, startTime: "10:00", endTime: "20:30" },
-      { day: 1, startTime: "10:00", endTime: "20:30" },
-      { day: 2, startTime: "10:00", endTime: "20:30" },
-      { day: 3, startTime: "10:00", endTime: "20:30" },
-      { day: 4, startTime: "10:00", endTime: "20:30" },
-      { day: 5, startTime: "10:00", endTime: "20:30" },
-      { day: 6, startTime: "10:00", endTime: "17:00" },
+      { day: 0, startTime: '10:00', endTime: '20:30' },
+      { day: 1, startTime: '10:00', endTime: '20:30' },
+      { day: 2, startTime: '10:00', endTime: '20:30' },
+      { day: 3, startTime: '10:00', endTime: '20:30' },
+      { day: 4, startTime: '10:00', endTime: '20:30' },
+      { day: 5, startTime: '10:00', endTime: '20:30' },
+      { day: 6, startTime: '10:00', endTime: '17:00' },
     ],
   },
 ];

--- a/src/api/placeApi.ts
+++ b/src/api/placeApi.ts
@@ -13,6 +13,20 @@ export const getPlaceDetail = async (id: number) => {
   return res.data.data;
 };
 
+export const getPlacesNearby = async (
+  userLat: number,
+  userLng: number,
+  cursorId?: number,
+  cursorDist?: number,
+  limit: number = 5
+) => {
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_NEARBY, {
+    params: { userLat, userLng, cursorId, cursorDist, limit },
+  });
+
+  return res.data.data;
+};
+
 export const fetchPlaceById = async (id: number) => {
   // await new Promise((res) => setTimeout(res, 300));
   return mockPlaces[id];

--- a/src/api/placeApi.ts
+++ b/src/api/placeApi.ts
@@ -7,6 +7,22 @@ export const fetchPlaces = async () => {
   return mockPlaces;
 };
 
+export const getPlacesRegion = async (
+  regionName: string,
+  userLat: number,
+  userLng: number,
+  category?: string,
+  cursorId?: number,
+  cursorDist?: number,
+  limit: number = 5
+) => {
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_REGION(regionName), {
+    params: { userLat, userLng, category, cursorId, cursorDist, limit },
+  });
+
+  return res.data.data;
+};
+
 export const getPlaceDetail = async (id: number) => {
   const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_DETAIL + id);
 

--- a/src/api/placeApi.ts
+++ b/src/api/placeApi.ts
@@ -8,6 +8,36 @@ export const fetchPlaces = async () => {
   return mockPlaces;
 };
 
+export const getPlacesByDisplay = async (
+  swLat: number, // swY - min
+  swLng: number, // swX
+  neLat: number, // neY - max
+  neLng: number, // neX
+  userLat: number,
+  userLng: number,
+  category?: string,
+  cursorId?: number,
+  cursorDist?: number,
+  limit: number = 5
+) => {
+  const response = await publicAxios.get(ENDPOINT.SOLMAP_PLACE, {
+    params: {
+      swLat,
+      swLng,
+      neLat,
+      neLng,
+      userLat,
+      userLng,
+      category,
+      cursorId,
+      cursorDist,
+      limit,
+    },
+  });
+
+  return response.data.data;
+};
+
 export const getPlacesByRegion = async (
   regionName: string,
   userLat: number,

--- a/src/api/placeApi.ts
+++ b/src/api/placeApi.ts
@@ -1,5 +1,6 @@
 import { Place } from '../types';
 import { publicAxios } from './axios';
+import qs from 'qs';
 import { ENDPOINT } from './urls';
 
 export const fetchPlaces = async () => {
@@ -7,7 +8,7 @@ export const fetchPlaces = async () => {
   return mockPlaces;
 };
 
-export const getPlacesRegion = async (
+export const getPlacesByRegion = async (
   regionName: string,
   userLat: number,
   userLng: number,
@@ -18,6 +19,20 @@ export const getPlacesRegion = async (
 ) => {
   const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_REGION(regionName), {
     params: { userLat, userLng, category, cursorId, cursorDist, limit },
+  });
+
+  return res.data.data;
+};
+
+export const getPlaceByIdList = async (
+  ids: number[],
+  cursorId?: number,
+  limit: number = 5
+) => {
+  const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_ID_LIST, {
+    params: { ids, cursorId, limit },
+    paramsSerializer: (params) =>
+      qs.stringify(params, { arrayFormat: 'repeat' }),
   });
 
   return res.data.data;

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -14,7 +14,7 @@ export const getRelatedSearchWords = async (
         userLng: userLng,
       },
     });
-    console.log(res);
+
     return res.data.data;
   } catch (e) {
     console.error(e);

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -5,6 +5,7 @@ export const BASE_URL = API_URL;
 export const ENDPOINT = {
   // solmap
   SOLMAP_MARKERS: '/api/solmap/markers',
+  SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
   RELATED_SEARCH: '/api/solmap/search/related',
 
   // solmap + sollect

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -7,11 +7,14 @@ export const ENDPOINT = {
   SOLMAP_MARKERS: '/api/solmap/markers',
   SOLMAP_MARKERS_REGION: (regionName: string) =>
     `/api/solmap/region/${regionName}/markers`,
+  SOLMAP_MARKERS_ID_LIST: '/api/solmap/markers/search/related',
+
   SOLMAP_PLACE_REGION: (regionName: string) =>
     `/api/solmap/region/${regionName}/places`,
   SOLMAP_PLACE_ID_LIST: '/api/solmap/places/search/related',
   SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
   SOLMAP_PLACE_NEARBY: '/api/solmap/places/nearby',
+
   RELATED_SEARCH: '/api/solmap/search/related',
 
   // solmap + sollect

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -5,6 +5,8 @@ export const BASE_URL = API_URL;
 export const ENDPOINT = {
   // solmap
   SOLMAP_MARKERS: '/api/solmap/markers',
+  SOLMAP_REGION_MARKERS: (regionName: string) =>
+    `/api/solmap/region/${regionName}/markers`,
   SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
   SOLMAP_PLACE_NEARBY: '/api/solmap/places/nearby',
   RELATED_SEARCH: '/api/solmap/search/related',

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -7,6 +7,8 @@ export const ENDPOINT = {
   SOLMAP_MARKERS: '/api/solmap/markers',
   SOLMAP_MARKERS_REGION: (regionName: string) =>
     `/api/solmap/region/${regionName}/markers`,
+  SOLMAP_PLACE_REGION: (regionName: string) =>
+    `/api/solmap/region/${regionName}/places`,
   SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
   SOLMAP_PLACE_NEARBY: '/api/solmap/places/nearby',
   RELATED_SEARCH: '/api/solmap/search/related',

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -9,6 +9,7 @@ export const ENDPOINT = {
     `/api/solmap/region/${regionName}/markers`,
   SOLMAP_MARKERS_ID_LIST: '/api/solmap/markers/search/related',
 
+  SOLMAP_PLACE: '/api/solmap/places',
   SOLMAP_PLACE_REGION: (regionName: string) =>
     `/api/solmap/region/${regionName}/places`,
   SOLMAP_PLACE_ID_LIST: '/api/solmap/places/search/related',

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -6,6 +6,7 @@ export const ENDPOINT = {
   // solmap
   SOLMAP_MARKERS: '/api/solmap/markers',
   SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
+  SOLMAP_PLACE_NEARBY: '/api/solmap/places/nearby',
   RELATED_SEARCH: '/api/solmap/search/related',
 
   // solmap + sollect

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -5,7 +5,7 @@ export const BASE_URL = API_URL;
 export const ENDPOINT = {
   // solmap
   SOLMAP_MARKERS: '/api/solmap/markers',
-  SOLMAP_REGION_MARKERS: (regionName: string) =>
+  SOLMAP_MARKERS_REGION: (regionName: string) =>
     `/api/solmap/region/${regionName}/markers`,
   SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
   SOLMAP_PLACE_NEARBY: '/api/solmap/places/nearby',

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -9,6 +9,7 @@ export const ENDPOINT = {
     `/api/solmap/region/${regionName}/markers`,
   SOLMAP_PLACE_REGION: (regionName: string) =>
     `/api/solmap/region/${regionName}/places`,
+  SOLMAP_PLACE_ID_LIST: '/api/solmap/places/search/related',
   SOLMAP_PLACE_DETAIL: '/api/solmap/place/search/',
   SOLMAP_PLACE_NEARBY: '/api/solmap/places/nearby',
   RELATED_SEARCH: '/api/solmap/search/related',

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -7,22 +7,8 @@ import Mark from '../assets/nav/mark.svg?react';
 import MarkActive from '../assets/nav/mark-active.svg?react';
 import Profile from '../assets/nav/profile.svg?react';
 import ProfileActive from '../assets/nav/profile-active.svg?react';
-import { useMapStore } from '../store/mapStore';
-import { useShallow } from 'zustand/shallow';
-import { getUserLocation } from '../utils/geolocation';
 
 const BottomNav = () => {
-  const { setInitCenter } = useMapStore(
-    useShallow((state) => ({
-      setInitCenter: state.setInitCenter,
-    }))
-  );
-
-  // solmap 바텀 메뉴 클릭시 InitCenter를 사용자 실시간 위치로 설정
-  const handleMapClick = async () => {
-    const { lat, lng } = await getUserLocation();
-    setInitCenter({ lat: lat, lng: lng });
-  };
   const menu = [
     {
       name: 'sollect',
@@ -35,7 +21,6 @@ const BottomNav = () => {
       path: '/map',
       icon: <Map />,
       activeIcon: <MapActive />,
-      onClick: handleMapClick,
     },
     { name: 'mark', path: '/mark', icon: <Mark />, activeIcon: <MarkActive /> },
     {
@@ -53,7 +38,6 @@ const BottomNav = () => {
           <NavLink
             key={item.name}
             to={item.path}
-            onClick={item.onClick}
             className='flex flex-col items-center gap-1'>
             {({ isActive }) => (isActive ? item.activeIcon : item.icon)}
           </NavLink>

--- a/src/components/BottomSheet/Category/CategoryButton.tsx
+++ b/src/components/BottomSheet/Category/CategoryButton.tsx
@@ -34,7 +34,7 @@ const CategoryButton: React.FC<CategoryButtonProps> = ({ category }) => {
 
   const handleClick = () => {
     setCategory(category.id);
-    navigate('list');
+    navigate('/map/list?queryType=category');
   };
 
   return (

--- a/src/components/BottomSheet/Category/MapChip.tsx
+++ b/src/components/BottomSheet/Category/MapChip.tsx
@@ -3,6 +3,7 @@ import { Category } from '../../../types';
 import { usePlaceStore } from '../../../store/placeStore';
 import { iconMap, iconBlackMap } from '../../../utils/icon';
 import { useNavigate } from 'react-router-dom';
+import { useShallow } from 'zustand/shallow';
 
 interface CategoryButtonProps {
   category: Category;
@@ -11,7 +12,12 @@ interface CategoryButtonProps {
 const MapChip: React.FC<CategoryButtonProps> = ({ category }) => {
   const navigate = useNavigate();
 
-  const { selectedCategory, setCategory } = usePlaceStore();
+  const { selectedCategory, setCategory } = usePlaceStore(
+    useShallow((state) => ({
+      selectedCategory: state.selectedCategory,
+      setCategory: state.setCategory,
+    }))
+  );
 
   const isSelected = selectedCategory === category.id;
 

--- a/src/components/BottomSheet/Category/MapChip.tsx
+++ b/src/components/BottomSheet/Category/MapChip.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import { Category } from '../../../types';
 import { usePlaceStore } from '../../../store/placeStore';
 import { iconMap, iconBlackMap } from '../../../utils/icon';
+import { useNavigate } from 'react-router-dom';
 
 interface CategoryButtonProps {
   category: Category;
 }
 
 const MapChip: React.FC<CategoryButtonProps> = ({ category }) => {
+  const navigate = useNavigate();
+
   const { selectedCategory, setCategory } = usePlaceStore();
+
   const isSelected = selectedCategory === category.id;
 
   const style = {
@@ -25,12 +29,17 @@ const MapChip: React.FC<CategoryButtonProps> = ({ category }) => {
     ? iconBlackMap[category.id]
     : iconMap[category.id];
 
+  const handleClick = () => {
+    setCategory(category.id);
+    navigate('/map/list?queryType=category');
+  };
+
   return (
     <>
       <button
         className='w-fit bg-white py-2 pl-8 pr-12 h-28 rounded-full border flex items-center justify-center shrink-0'
         style={style}
-        onClick={() => setCategory(category.id)}>
+        onClick={handleClick}>
         <IconComponent />
         <div className='text-xs font-medium'>{category.title}</div>
       </button>

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -19,7 +19,8 @@ const DetailContent: React.FC = () => {
     enabled: !!placeId,
   });
 
-  // complete api: 마커 클릭시 해당 마커의 상세정보 호출
+  // complete api: 마커 클릭시 해당 장소 상세정보 호출
+  // complete api: 검색 결과에서 특정 장소 클릭시 상세 정보 호출
   useEffect(() => {
     console.log('placeDetail:', data);
   }, [data]);

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -4,12 +4,26 @@ import ReviewRange from './ReviewRange';
 import TagList from './TagList';
 import ReviewPhotos from './ReviewPhotos';
 import ReviewList from './Review/ReviewList';
-import { fetchPlaceById } from '../../api/placeApi';
+import { fetchPlaceById, getPlaceDetail } from '../../api/placeApi';
 import { usePlaceStore } from '../../store/placeStore';
 import { Link, useParams } from 'react-router-dom';
-import arrow from "../../assets/arrow.svg"
+import arrow from '../../assets/arrow.svg';
+import { useQuery } from '@tanstack/react-query';
 
 const DetailContent: React.FC = () => {
+  const { placeId } = useParams<{ placeId: string }>();
+
+  const { data } = useQuery({
+    queryKey: ['placeDetail', placeId],
+    queryFn: () => getPlaceDetail(parseInt(placeId!)),
+    enabled: !!placeId,
+  });
+
+  // complete api: 마커 클릭시 해당 마커의 상세정보 호출
+  useEffect(() => {
+    console.log('placeDetail:', data);
+  }, [data]);
+
   const { selectedPlace } = usePlaceStore();
   const counts = [2, 3, 1];
 
@@ -21,8 +35,6 @@ const DetailContent: React.FC = () => {
     'https://dynamic-media-cdn.tripadvisor.com/media/photo-o/15/cc/5b/8f/various-breads.jpg?w=800&h=-1&s=1',
     'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
   ];
-
-  const { placeId } = useParams<{ placeId: string }>();
 
   useEffect(() => {
     if (placeId) {
@@ -62,12 +74,19 @@ const DetailContent: React.FC = () => {
       <ReviewPhotos images={images} more />
 
       {/* 관련 쏠렉트 보기 */}
-      <Link className='flex text-primary-950 text-xs pl-16 mb-12' to='/related-sollect'>
+      <Link
+        className='flex text-primary-950 text-xs pl-16 mb-12'
+        to='/related-sollect'>
         관련 쏠렉트 보기 <img src={arrow} alt='arrow' />
       </Link>
 
       {/* ReviewList */}
-      {placeId && <ReviewList placeId={parseInt(placeId)} placeName={selectedPlace.title} />}
+      {placeId && (
+        <ReviewList
+          placeId={parseInt(placeId)}
+          placeName={selectedPlace.title}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
@@ -18,7 +18,7 @@ const PreviewContentEmpty: React.FC = () => {
 
   // complete api: 검색결과 없을 시 유저 위치 기반 거리순 추천 장소 리스트 호출
   useEffect(() => {
-    console.log('placeDetail:', data);
+    console.log('placeRecommanded:', data);
   }, [data]);
 
   return (

--- a/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
@@ -1,9 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PreviewContent from './PreviewContent';
 import { usePlaceStore } from '../../../store/placeStore';
+import { useQuery } from '@tanstack/react-query';
+import { useMapStore } from '../../../store/mapStore';
+import { getPlacesNearby } from '../../../api/placeApi';
 
 const PreviewContentEmpty: React.FC = () => {
   const filteredPlaces = usePlaceStore((state) => state.filteredPlaces);
+
+  const { userLatLng } = useMapStore();
+
+  const { data } = useQuery({
+    queryKey: ['placesNearby', userLatLng],
+    queryFn: () => getPlacesNearby(userLatLng!.lat, userLatLng!.lng), // [원본 코드]
+    // queryFn: () => getPlacesNearby(37.51234, 127.060395), // [대체 코드] 만약 본인 주변에 장소가 없다고 나온다면 이것을 주석을 풀어서 사용할 것 / todo : 배포할 때 풀어서 배포하기
+    enabled: !!userLatLng,
+  });
+
+  // complete api: 검색결과 없을 시 유저 위치 기반 거리순 추천 장소 리스트 호출
+  useEffect(() => {
+    console.log('placeDetail:', data);
+  }, [data]);
+
   return (
     <div>
       <div className='flex py-80 flex-col items-start'>

--- a/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
@@ -12,8 +12,7 @@ const PreviewContentEmpty: React.FC = () => {
 
   const { data } = useQuery({
     queryKey: ['placesNearby', userLatLng],
-    queryFn: () => getPlacesNearby(userLatLng!.lat, userLatLng!.lng), // [원본 코드]
-    // queryFn: () => getPlacesNearby(37.51234, 127.060395), // [대체 코드] 만약 본인 주변에 장소가 없다고 나온다면 이것을 주석을 풀어서 사용할 것 / todo : 배포할 때 풀어서 배포하기
+    queryFn: () => getPlacesNearby(userLatLng!.lat, userLatLng!.lng),
     enabled: !!userLatLng,
   });
 

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -1,9 +1,38 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PreviewContent from './PreviewContent';
 import { usePlaceStore } from '../../../store/placeStore';
+import { useMapStore } from '../../../store/mapStore';
+import { useShallow } from 'zustand/shallow';
+import { useSearchParams } from 'react-router-dom';
+import { useSearchStore } from '../../../store/searchStore';
+import { useQuery } from '@tanstack/react-query';
+import { getPlacesRegion } from '../../../api/placeApi';
 
 const PreviewContentList: React.FC = () => {
-const filteredPlaces = usePlaceStore((state)=>state.filteredPlaces);
+  const filteredPlaces = usePlaceStore((state) => state.filteredPlaces);
+
+  const [searchParams] = useSearchParams();
+  const queryType = searchParams.get('queryType');
+
+  const { userLatLng } = useMapStore(
+    useShallow((state) => ({
+      userLatLng: state.userLatLng,
+    }))
+  );
+
+  const { selectedRegion } = useSearchStore();
+
+  const placesRegionQuery = useQuery({
+    queryKey: ['placesRegion'],
+    queryFn: () =>
+      getPlacesRegion(selectedRegion, userLatLng!.lat, userLatLng!.lng),
+    enabled: queryType === 'region',
+  });
+
+  // complete api: 지역 이름으로 프리뷰 리스트 호출 api
+  useEffect(() => {
+    console.log('placesRegionQuery:', placesRegionQuery.data);
+  }, [placesRegionQuery]);
 
   return (
     <div>

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -6,17 +6,27 @@ import { useShallow } from 'zustand/shallow';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchStore } from '../../../store/searchStore';
 import { useQuery } from '@tanstack/react-query';
-import { getPlaceByIdList, getPlacesByRegion } from '../../../api/placeApi';
+import {
+  getPlaceByIdList,
+  getPlacesByDisplay,
+  getPlacesByRegion,
+} from '../../../api/placeApi';
 
 const PreviewContentList: React.FC = () => {
-  const filteredPlaces = usePlaceStore((state) => state.filteredPlaces);
-
   const [searchParams] = useSearchParams();
   const queryType = searchParams.get('queryType');
 
-  const { userLatLng } = useMapStore(
+  const { filteredPlaces, selectedCategory } = usePlaceStore(
+    useShallow((state) => ({
+      filteredPlaces: state.filteredPlaces,
+      selectedCategory: state.selectedCategory,
+    }))
+  );
+
+  const { userLatLng, lastBounds } = useMapStore(
     useShallow((state) => ({
       userLatLng: state.userLatLng,
+      lastBounds: state.lastBounds,
     }))
   );
 
@@ -40,15 +50,35 @@ const PreviewContentList: React.FC = () => {
     enabled: queryType === 'idList',
   });
 
+  const placesDisplayQuery = useQuery({
+    queryKey: ['placesDisplay', lastBounds, userLatLng, selectedCategory],
+    queryFn: () =>
+      getPlacesByDisplay(
+        lastBounds!.getMin().y,
+        lastBounds!.getMin().x,
+        lastBounds!.getMax().y,
+        lastBounds!.getMax().x,
+        userLatLng!.lat,
+        userLatLng!.lng,
+        selectedCategory ?? undefined
+      ),
+    enabled: queryType === 'category',
+  });
+
   // complete api: 지역 이름으로 프리뷰 리스트 호출 api
   useEffect(() => {
-    console.log('placesRegionQuery:', placesRegionQuery.data);
+    console.log('places[Region]Query:', placesRegionQuery.data);
   }, [placesRegionQuery]);
 
   // complete api: 검색창에서 enter시 연관검색어에서 추출한 장소 id 리스트로 프리뷰 리스트 호출 api
   useEffect(() => {
-    console.log('placesIdListQuery:', placesIdListQuery.data);
+    console.log('places[IdList]Query:', placesIdListQuery.data);
   }, [placesIdListQuery]);
+
+  // complete api: 카테고리 선택시 현재 화면 기준으로 프리뷰 리스트 호출 api
+  useEffect(() => {
+    console.log('places[Display]Query:', placesDisplayQuery.data);
+  }, [placesDisplayQuery]);
 
   return (
     <div>

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -6,7 +6,7 @@ import { useShallow } from 'zustand/shallow';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchStore } from '../../../store/searchStore';
 import { useQuery } from '@tanstack/react-query';
-import { getPlacesRegion } from '../../../api/placeApi';
+import { getPlaceByIdList, getPlacesByRegion } from '../../../api/placeApi';
 
 const PreviewContentList: React.FC = () => {
   const filteredPlaces = usePlaceStore((state) => state.filteredPlaces);
@@ -20,19 +20,35 @@ const PreviewContentList: React.FC = () => {
     }))
   );
 
-  const { selectedRegion } = useSearchStore();
+  const { selectedRegion, relatedPlaceIdList } = useSearchStore(
+    useShallow((state) => ({
+      selectedRegion: state.selectedRegion,
+      relatedPlaceIdList: state.relatedPlaceIdList,
+    }))
+  );
 
   const placesRegionQuery = useQuery({
     queryKey: ['placesRegion'],
     queryFn: () =>
-      getPlacesRegion(selectedRegion, userLatLng!.lat, userLatLng!.lng),
+      getPlacesByRegion(selectedRegion, userLatLng!.lat, userLatLng!.lng),
     enabled: queryType === 'region',
+  });
+
+  const placesIdListQuery = useQuery({
+    queryKey: ['placesIdList'],
+    queryFn: () => getPlaceByIdList(relatedPlaceIdList),
+    enabled: queryType === 'idList',
   });
 
   // complete api: 지역 이름으로 프리뷰 리스트 호출 api
   useEffect(() => {
     console.log('placesRegionQuery:', placesRegionQuery.data);
   }, [placesRegionQuery]);
+
+  // complete api: 검색창에서 enter시 연관검색어에서 추출한 장소 id 리스트로 프리뷰 리스트 호출 api
+  useEffect(() => {
+    console.log('placesIdListQuery:', placesIdListQuery.data);
+  }, [placesIdListQuery]);
 
   return (
     <div>

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -332,6 +332,8 @@ const MapSheet = () => {
     const { objectList, idList } = result;
     setNewMarkerObjectList(objectList);
     setMarkerIdList(idList);
+
+    navigate('/map/list?queryType=category');
   }, [lastBounds, selectedCategory]);
 
   /* 실시간 사용자 위치로 지도 이동 */

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -29,7 +29,7 @@ const initMap = (
   if (!divRef.current) return;
 
   const MapOptions = {
-    zoom: lastZoom || 16,
+    zoom: lastZoom,
     center: lastBounds?.getCenter() || center,
     gl: true,
     customStyleId: import.meta.env.VITE_MAP_STYLE_ID,

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -318,12 +318,13 @@ const MapSheet = () => {
   const researchMarker = useCallback(async () => {
     if (!mapInstance.current) return;
 
-    const currentBounds = mapInstance.current.getBounds();
+    console.log('selectedCategory:', selectedCategory);
+
     const data = await getMarkersByDisplay(
-      currentBounds.getMin().y,
-      currentBounds.getMin().x,
-      currentBounds.getMax().y,
-      currentBounds.getMax().x,
+      lastBounds!.getMin().y,
+      lastBounds!.getMin().x,
+      lastBounds!.getMax().y,
+      lastBounds!.getMax().x,
       selectedCategory ?? undefined
     );
 
@@ -331,7 +332,7 @@ const MapSheet = () => {
     const { objectList, idList } = result;
     setNewMarkerObjectList(objectList);
     setMarkerIdList(idList);
-  }, []);
+  }, [lastBounds, selectedCategory]);
 
   /* 실시간 사용자 위치로 지도 이동 */
   const moveToUserLocation = useCallback(async () => {

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -195,7 +195,7 @@ const MapSheet = () => {
     const newBounds = map.getBounds();
 
     // 추가할 마커 객체가 없으면 getDisplayMarkers api 호출
-    if (!newMarkerObjectList) {
+    if (newMarkerObjectList === null) {
       getDisplayMarkers(
         newBounds.getMin().x,
         newBounds.getMin().y,
@@ -203,15 +203,9 @@ const MapSheet = () => {
         newBounds.getMax().y
       ).then((res) => {
         const result = createMarkerObjectList(res);
-        if (!result) {
-          setNewMarkerObjectList(null);
-          setMarkerIdList(null);
-          return;
-        } else {
-          const { objectList, idList } = result;
-          setNewMarkerObjectList(objectList);
-          setMarkerIdList(idList);
-        }
+        const { objectList, idList } = result;
+        setNewMarkerObjectList(objectList);
+        setMarkerIdList(idList);
       });
     }
 

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../utils/mapFunc';
 import { useSearchStore } from '../../store/searchStore';
 import { getPlaceDetail } from '../../api/placeApi';
+import { usePlaceStore } from '../../store/placeStore';
 
 /* 지도 생성 */
 const initMap = (
@@ -182,6 +183,8 @@ const MapSheet = () => {
     }))
   );
 
+  const { selectedCategory } = usePlaceStore();
+
   /* [useLayoutEffect] 지도 생성 및 초기 마커 추가 */
   useLayoutEffect(() => {
     if (!mapElement.current) return;
@@ -238,7 +241,20 @@ const MapSheet = () => {
   useEffect(() => {
     const fetchMarkers = async () => {
       try {
-        if (queryType === 'region' && selectedRegion) {
+        if (queryType === 'category') {
+          // 카테고리 선택시 마커 표시
+          const newInfo = await getMarkersByDisplay(
+            lastBounds!.getMin().y,
+            lastBounds!.getMin().x,
+            lastBounds!.getMax().y,
+            lastBounds!.getMax().x,
+            selectedCategory ?? undefined
+          );
+          const result = createMarkerObjectList(newInfo);
+          const { objectList, idList } = result;
+          setNewMarkerObjectList(objectList);
+          setMarkerIdList(idList);
+        } else if (queryType === 'region' && selectedRegion) {
           // 검색창에서 지역명 선택/enter시 마커 표시
           const newInfo = await getMarkersByRegion(selectedRegion);
           const result = createMarkerObjectList(newInfo);
@@ -267,7 +283,7 @@ const MapSheet = () => {
     };
 
     fetchMarkers();
-  }, [queryType, selectedRegion, detailType, placeId]);
+  }, [queryType, selectedCategory, selectedRegion, detailType, placeId]);
 
   const applyMarkerResult = (
     result: ReturnType<typeof createMarkerObjectList>
@@ -307,7 +323,8 @@ const MapSheet = () => {
       currentBounds.getMin().y,
       currentBounds.getMin().x,
       currentBounds.getMax().y,
-      currentBounds.getMax().x
+      currentBounds.getMax().x,
+      selectedCategory ?? undefined
     );
 
     const result = createMarkerObjectList(data);

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -54,10 +54,10 @@ const initMap = (
 const addMarkers = (
   mapRef: React.RefObject<naver.maps.Map | null>,
   objectList: naver.maps.Marker[] | null,
-  markerIdList: number[],
+  markerIdList: number[] | null,
   navigate: NavigateFunction
 ) => {
-  if (!mapRef.current || !objectList) return;
+  if (!mapRef.current || !objectList || !markerIdList) return;
 
   objectList.forEach((m: naver.maps.Marker, index: number) => {
     // 지도에 마커 객체 설정
@@ -194,10 +194,14 @@ const MapSheet = () => {
         newBounds.getMax().y
       ).then((res) => {
         const result = createMarkerObjectList(res);
-        if (!result) return;
-        const { objectList, idList } = result;
-        setNewMarkerObjectList(objectList);
-        setMarkerIdList(idList);
+        if (!result) {
+          setNewMarkerObjectList(null);
+          setMarkerIdList(null);
+        } else {
+          const { objectList, idList } = result;
+          setNewMarkerObjectList(objectList);
+          setMarkerIdList(idList);
+        }
       });
     }
 
@@ -231,11 +235,16 @@ const MapSheet = () => {
       currentBounds.getMax().x,
       currentBounds.getMax().y
     );
+
     const result = createMarkerObjectList(data);
-    if (!result) return;
-    const { objectList, idList } = result;
-    setNewMarkerObjectList(objectList);
-    setMarkerIdList(idList);
+    if (!result) {
+      setNewMarkerObjectList(null);
+      setMarkerIdList(null);
+    } else {
+      const { objectList, idList } = result;
+      setNewMarkerObjectList(objectList);
+      setMarkerIdList(idList);
+    }
   }, []);
 
   /* 실시간 사용자 위치로 지도 이동 */

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -216,10 +216,10 @@ const MapSheet = () => {
     // 초기 마커 추가
     if (newMarkerObjectList === null) {
       getMarkersByDisplay(
-        newBounds.getMin().x,
         newBounds.getMin().y,
-        newBounds.getMax().x,
-        newBounds.getMax().y
+        newBounds.getMin().x,
+        newBounds.getMax().y,
+        newBounds.getMax().x
       ).then((res) => {
         const result = createMarkerObjectList(res);
         const { objectList, idList } = result;
@@ -304,10 +304,10 @@ const MapSheet = () => {
 
     const currentBounds = mapInstance.current.getBounds();
     const data = await getMarkersByDisplay(
-      currentBounds.getMin().x,
       currentBounds.getMin().y,
-      currentBounds.getMax().x,
-      currentBounds.getMax().y
+      currentBounds.getMin().x,
+      currentBounds.getMax().y,
+      currentBounds.getMax().x
     );
 
     const result = createMarkerObjectList(data);

--- a/src/components/Searching/RecentSearch.tsx
+++ b/src/components/Searching/RecentSearch.tsx
@@ -23,7 +23,7 @@ interface RecentSearchTextProps {
 const RecentSearch: React.FC<RecentSearchTextProps> = ({ text, mode }) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  
+
   const { clearCategory } = useSollectStore();
 
   const { userLatLng } = useMapStore();
@@ -47,53 +47,44 @@ const RecentSearch: React.FC<RecentSearchTextProps> = ({ text, mode }) => {
   const handleClick = async () => {
     setInputValue(text);
 
-    const relatedSearchList = await getRelatedSearchWords(
-      text,
-      userLatLng!.lat,
-      userLatLng!.lng
-    );
-
-    if (
-      relatedSearchList.length === 1 &&
-      relatedSearchList[0].type === 'PLACE'
-    ) {
-      // 디테일 페이지로 이동
-      navigate(`/map/detail/${relatedSearchList[0].id}?detailType=searching`);
-    } else {
-      // 프리뷰 리스트 페이지로 이동
-      const anyResult = extractRegionOrPlaceIds(relatedSearchList);
-      if (Array.isArray(anyResult)) {
-        // 장소 id 리스트
-        setRelatedPlaceIdList(anyResult);
-        navigate('/map/list?queryType=idList');
-      } else {
-        // 지역명
-        setSelectedRegion(anyResult);
-        navigate('/map/list?queryType=region');
-      }
-    }
-
-    setCategory(null);
-  };
-
-  const { setInputValue } = useSearchStore();
-  const navigate = useNavigate();
-
-  const handleClick = async () => {
-    setInputValue(text);
-    if(mode === "sollect"){
+    if (mode === 'sollect') {
       clearCategory();
       navigate('/sollect/search/result');
-    }else if(mode === "solmap"){
-      // TODO: list page에서 searchPlace 해야함
-      navigate('/map/list');
+    } else if (mode === 'solmap') {
+      const relatedSearchList = await getRelatedSearchWords(
+        text,
+        userLatLng!.lat,
+        userLatLng!.lng
+      );
+
+      if (
+        relatedSearchList.length === 1 &&
+        relatedSearchList[0].type === 'PLACE'
+      ) {
+        // 디테일 페이지로 이동
+        navigate(`/map/detail/${relatedSearchList[0].id}?detailType=searching`);
+      } else {
+        // 프리뷰 리스트 페이지로 이동
+        const anyResult = extractRegionOrPlaceIds(relatedSearchList);
+        if (Array.isArray(anyResult)) {
+          // 장소 id 리스트
+          setRelatedPlaceIdList(anyResult);
+          navigate('/map/list?queryType=idList');
+        } else {
+          // 지역명
+          setSelectedRegion(anyResult);
+          navigate('/map/list?queryType=region');
+        }
+      }
+
+      setCategory(null);
     }
+
     await postRecentSearchWord(text, mode);
   };
 
   return (
-    <div
-      className='flex pt-8 pl-12 pr-8 pb-0 items-center gap-10'>
+    <div className='flex pt-8 pl-12 pr-8 pb-0 items-center gap-10'>
       <div className='flex h-36 items-center gap-4 flex-[1_0_0] justify-start'>
         <div
           className='flex items-center gap-4 flex-[1_0_0]'

--- a/src/components/Searching/RecentSearch.tsx
+++ b/src/components/Searching/RecentSearch.tsx
@@ -2,8 +2,16 @@ import React from 'react';
 import xBottonCircle from '../../assets/xButtonCircle.svg';
 import ClockFill from '../../assets/clockFill.svg?react';
 import XButtonCircle from '../XButtonCircle';
-import { deleteRecentSearchWords } from '../../api/searchApi';
+import {
+  deleteRecentSearchWords,
+  getRelatedSearchWords,
+} from '../../api/searchApi';
 import { useQueryClient } from '@tanstack/react-query';
+import { useMapStore } from '../../store/mapStore';
+import { extractRegionOrPlaceIds } from '../../utils/placeFunc';
+import { useNavigate } from 'react-router-dom';
+import { useSearchStore } from '../../store/searchStore';
+import { useShallow } from 'zustand/shallow';
 
 interface RecentSearchTextProps {
   text: string;
@@ -11,23 +19,63 @@ interface RecentSearchTextProps {
 }
 
 const RecentSearch: React.FC<RecentSearchTextProps> = ({ text, mode }) => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  async function onClickDeleteRow() {
+  const { userLatLng } = useMapStore();
+
+  const { setRelatedPlaceIdList, setSelectedRegion } = useSearchStore(
+    useShallow((state) => ({
+      setRelatedPlaceIdList: state.setRelatedPlaceIdList,
+      setSelectedRegion: state.setSelectedRegion,
+    }))
+  );
+
+  const onClickDeleteRow = async () => {
     await deleteRecentSearchWords(mode, text);
     queryClient.invalidateQueries({ queryKey: ['recentSearchWords'] });
-  }
+  };
+
+  const handleClick = async () => {
+    const relatedSearchList = await getRelatedSearchWords(
+      text,
+      userLatLng!.lat,
+      userLatLng!.lng
+    );
+
+    if (
+      relatedSearchList.length === 1 &&
+      relatedSearchList[0].type === 'PLACE'
+    ) {
+      // 디테일 페이지로 이동
+      navigate(`/map/detail/${relatedSearchList[0].id}?detailType=searching`);
+    } else {
+      // 프리뷰 리스트 페이지로 이동
+      const anyResult = extractRegionOrPlaceIds(relatedSearchList);
+      if (Array.isArray(anyResult)) {
+        // 장소 id 리스트
+        setRelatedPlaceIdList(anyResult);
+        navigate('/map/list?queryType=idList');
+      } else {
+        // 지역명
+        setSelectedRegion(anyResult);
+        navigate('/map/list?queryType=region');
+      }
+    }
+  };
 
   return (
     <div className='flex pt-8 pl-12 pr-8 pb-0 items-center gap-10'>
       <div className='flex h-36 items-center gap-4 flex-[1_0_0] justify-start'>
-        <div className='flex items-center gap-4 flex-[1_0_0]'>
+        <div
+          className='flex items-center gap-4 flex-[1_0_0]'
+          onClick={handleClick}>
           <ClockFill />
           <div className='flex-[1_0_0] text-[12px] leading-[120%] tracking-[-0.18px] text-primary-950'>
             {text}
           </div>
         </div>
-      
+
         <XButtonCircle onClickFunc={() => onClickDeleteRow()} />
       </div>
     </div>

--- a/src/components/Searching/RecentSearch.tsx
+++ b/src/components/Searching/RecentSearch.tsx
@@ -12,6 +12,7 @@ import { extractRegionOrPlaceIds } from '../../utils/placeFunc';
 import { useNavigate } from 'react-router-dom';
 import { useSearchStore } from '../../store/searchStore';
 import { useShallow } from 'zustand/shallow';
+import { usePlaceStore } from '../../store/placeStore';
 
 interface RecentSearchTextProps {
   text: string;
@@ -24,12 +25,16 @@ const RecentSearch: React.FC<RecentSearchTextProps> = ({ text, mode }) => {
 
   const { userLatLng } = useMapStore();
 
-  const { setRelatedPlaceIdList, setSelectedRegion } = useSearchStore(
-    useShallow((state) => ({
-      setRelatedPlaceIdList: state.setRelatedPlaceIdList,
-      setSelectedRegion: state.setSelectedRegion,
-    }))
-  );
+  const { setRelatedPlaceIdList, setSelectedRegion, setInputValue } =
+    useSearchStore(
+      useShallow((state) => ({
+        setRelatedPlaceIdList: state.setRelatedPlaceIdList,
+        setSelectedRegion: state.setSelectedRegion,
+        setInputValue: state.setInputValue,
+      }))
+    );
+
+  const { setCategory } = usePlaceStore();
 
   const onClickDeleteRow = async () => {
     await deleteRecentSearchWords(mode, text);
@@ -37,6 +42,8 @@ const RecentSearch: React.FC<RecentSearchTextProps> = ({ text, mode }) => {
   };
 
   const handleClick = async () => {
+    setInputValue(text);
+
     const relatedSearchList = await getRelatedSearchWords(
       text,
       userLatLng!.lat,
@@ -62,6 +69,8 @@ const RecentSearch: React.FC<RecentSearchTextProps> = ({ text, mode }) => {
         navigate('/map/list?queryType=region');
       }
     }
+
+    setCategory(null);
   };
 
   return (

--- a/src/components/Searching/RelatedSearch.tsx
+++ b/src/components/Searching/RelatedSearch.tsx
@@ -3,6 +3,9 @@ import { RelatedSearchWord } from '../../types';
 import { iconRelatedSearch } from '../../utils/icon';
 import { useNavigate } from 'react-router-dom';
 import { useSearchStore } from '../../store/searchStore';
+import { postRecentSearchWord } from '../../api/searchApi';
+import { usePlaceStore } from '../../store/placeStore';
+import { useShallow } from 'zustand/shallow';
 
 interface RelatedSearchProps {
   relatedSearchWord: RelatedSearchWord;
@@ -11,12 +14,23 @@ interface RelatedSearchProps {
 const RelatedSearch: React.FC<RelatedSearchProps> = ({ relatedSearchWord }) => {
   const navigate = useNavigate();
 
-  const { setSelectedRegion } = useSearchStore();
+  const { setSelectedRegion, setInputValue } = useSearchStore(
+    useShallow((state) => ({
+      setSelectedRegion: state.setSelectedRegion,
+      setInputValue: state.setInputValue,
+    }))
+  );
+
+  const { setCategory } = usePlaceStore();
 
   const IconComponent =
     relatedSearchWord.type === 'PLACE'
       ? iconRelatedSearch[relatedSearchWord.category!]
       : iconRelatedSearch['location'];
+
+  const mode = window.location.pathname.includes('/sollect/search')
+    ? 'sollect'
+    : 'solmap';
 
   const clickResult = async () => {
     if (relatedSearchWord.type === 'PLACE') {
@@ -27,6 +41,10 @@ const RelatedSearch: React.FC<RelatedSearchProps> = ({ relatedSearchWord }) => {
       setSelectedRegion(relatedSearchWord.name);
       navigate('/map/list?queryType=region');
     }
+
+    setInputValue(relatedSearchWord.name);
+    postRecentSearchWord(relatedSearchWord.name, mode);
+    setCategory(null);
   };
 
   return (

--- a/src/components/Searching/RelatedSearch.tsx
+++ b/src/components/Searching/RelatedSearch.tsx
@@ -20,7 +20,8 @@ const RelatedSearch: React.FC<RelatedSearchProps> = ({ relatedSearchWord }) => {
 
   const clickResult = async () => {
     if (relatedSearchWord.type === 'PLACE') {
-      // todo : 상세정보 api로 마커+디테일뷰 한 번에 불러오기
+      // 클릭한 장소 디테일뷰로 이동
+      navigate(`/map/detail/${relatedSearchWord.id}?detailType=searching`);
     } else if (relatedSearchWord.type === 'DISTRICT') {
       // 클릭한 지역명 저장
       setSelectedRegion(relatedSearchWord.name);

--- a/src/components/Searching/RelatedSearch.tsx
+++ b/src/components/Searching/RelatedSearch.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 import { RelatedSearchWord } from '../../types';
 import { iconRelatedSearch } from '../../utils/icon';
 import { useNavigate } from 'react-router-dom';
-import { useMapStore } from '../../store/mapStore';
-import { useShallow } from 'zustand/shallow';
-import { useMarkerStore } from '../../store/markerStore';
-import { getRegionMarkers } from '../../api/mapApi';
-import {
-  createMarkerObjectList,
-  createMarkersBounds,
-} from '../../utils/mapFunc';
+import { useSearchStore } from '../../store/searchStore';
 
 interface RelatedSearchProps {
   relatedSearchWord: RelatedSearchWord;
@@ -18,19 +11,7 @@ interface RelatedSearchProps {
 const RelatedSearch: React.FC<RelatedSearchProps> = ({ relatedSearchWord }) => {
   const navigate = useNavigate();
 
-  const { setIsSearchBounds, setLastBounds } = useMapStore(
-    useShallow((state) => ({
-      setIsSearchBounds: state.setIsSearchBounds,
-      setLastBounds: state.setLastBounds,
-    }))
-  );
-
-  const { setNewMarkerObjectList, setMarkerIdList } = useMarkerStore(
-    useShallow((state) => ({
-      setNewMarkerObjectList: state.setNewMarkerObjectList,
-      setMarkerIdList: state.setMarkerIdList,
-    }))
-  );
+  const { setSelectedRegion } = useSearchStore();
 
   const IconComponent =
     relatedSearchWord.type === 'PLACE'
@@ -41,20 +22,10 @@ const RelatedSearch: React.FC<RelatedSearchProps> = ({ relatedSearchWord }) => {
     if (relatedSearchWord.type === 'PLACE') {
       // todo : 상세정보 api로 마커+디테일뷰 한 번에 불러오기
     } else if (relatedSearchWord.type === 'DISTRICT') {
-      // getRegionMarkers api 호출
-      const newInfo = await getRegionMarkers(relatedSearchWord.name);
-      // 새로운 마커 객체(+ idList) 생성 및 저장
-      const result = createMarkerObjectList(newInfo);
-      const { objectList, idList } = result!;
-      setNewMarkerObjectList(objectList);
-      setMarkerIdList(idList);
-      // 새로운 bounds 생성 및 저장
-      const newBounds = createMarkersBounds(objectList);
-      setIsSearchBounds(true);
-      setLastBounds(newBounds);
-      // todo : 지역정보 api로 장소 리스트 불러오기
+      // 클릭한 지역명 저장
+      setSelectedRegion(relatedSearchWord.name);
+      navigate('/map/list?queryType=region');
     }
-    navigate('/map/list');
   };
 
   return (

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -6,19 +6,33 @@ import { postRecentSearchWord } from '../../api/searchApi';
 import { useShallow } from 'zustand/shallow';
 import { searchSollect } from '../../api/sollectApi';
 import { useNavigate } from 'react-router-dom';
+import { useMarkerStore } from '../../store/markerStore';
 
 const SearchBar: React.FC = () => {
   const navigate = useNavigate();
 
-  const { inputValue, setInputValue, relatedSearchList, setRelatedSearchList } =
-    useSearchStore(
+  const {
+    inputValue,
+    setInputValue,
+    relatedSearchList,
+    setRelatedSearchList,
+    setSelectedRegion,
+  } = useSearchStore(
       useShallow((state) => ({
         inputValue: state.inputValue,
         setInputValue: state.setInputValue,
         relatedSearchList: state.relatedSearchList,
         setRelatedSearchList: state.setRelatedSearchList,
+      setSelectedRegion: state.setSelectedRegion,
       }))
     );
+
+  const { setMarkerIdList, setNewMarkerObjectList } = useMarkerStore(
+    useShallow((state) => ({
+      setMarkerIdList: state.setMarkerIdList,
+      setNewMarkerObjectList: state.setNewMarkerObjectList,
+    }))
+  );
 
   const mode = window.location.pathname.includes('/sollect/search')
     ? 'sollect'
@@ -37,6 +51,9 @@ const SearchBar: React.FC = () => {
       if (relatedSearchList.length > 0) {
         navigate('/map/list');
       } else {
+        setSelectedRegion('');
+        setMarkerIdList([]);
+        setNewMarkerObjectList([]);
         navigate('/map/not-found');
       }
     }

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -18,6 +18,7 @@ const SearchBar: React.FC = () => {
     relatedSearchList,
     setRelatedSearchList,
     setSelectedRegion,
+    setRelatedPlaceIdList,
   } = useSearchStore(
     useShallow((state) => ({
       inputValue: state.inputValue,
@@ -25,6 +26,7 @@ const SearchBar: React.FC = () => {
       relatedSearchList: state.relatedSearchList,
       setRelatedSearchList: state.setRelatedSearchList,
       setSelectedRegion: state.setSelectedRegion,
+      setRelatedPlaceIdList: state.setRelatedPlaceIdList,
     }))
   );
 
@@ -60,6 +62,8 @@ const SearchBar: React.FC = () => {
         const anyResult = extractRegionOrPlaceIds(relatedSearchList);
         if (Array.isArray(anyResult)) {
           // 장소 id 리스트 반환시
+          setRelatedPlaceIdList(anyResult);
+          navigate('/map/list?queryType=idList');
         } else {
           // 지역명 반환시
           setSelectedRegion(anyResult);

--- a/src/components/Searching/SearchBar.tsx
+++ b/src/components/Searching/SearchBar.tsx
@@ -18,14 +18,14 @@ const SearchBar: React.FC = () => {
     setRelatedSearchList,
     setSelectedRegion,
   } = useSearchStore(
-      useShallow((state) => ({
-        inputValue: state.inputValue,
-        setInputValue: state.setInputValue,
-        relatedSearchList: state.relatedSearchList,
-        setRelatedSearchList: state.setRelatedSearchList,
+    useShallow((state) => ({
+      inputValue: state.inputValue,
+      setInputValue: state.setInputValue,
+      relatedSearchList: state.relatedSearchList,
+      setRelatedSearchList: state.setRelatedSearchList,
       setSelectedRegion: state.setSelectedRegion,
-      }))
-    );
+    }))
+  );
 
   const { setMarkerIdList, setNewMarkerObjectList } = useMarkerStore(
     useShallow((state) => ({

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -36,7 +36,6 @@ const Solmap: React.FC = () => {
     watchIdRef.current = watchUserLocation(
       (position) => {
         const { latitude, longitude } = position.coords;
-        console.log(latitude, longitude);
         setUserLatLng({ lat: latitude, lng: longitude });
       },
       (error) => {

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import BottomSheet from '../components/BottomSheet/BottomSheet';
 import { Outlet } from 'react-router-dom';
 import SearchArea from '../components/Searching/SearchArea';
@@ -9,16 +9,49 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchPlaces } from '../api/placeApi';
 import MapSheet from '../components/Map/MapSheet';
 import MapSearchBar from '../components/Searching/MapSearchBar';
+import { watchUserLocation } from '../utils/geolocation';
+import { useMapStore } from '../store/mapStore';
+import { useShallow } from 'zustand/shallow';
 
 const Solmap: React.FC = () => {
+  const watchIdRef = useRef<number | null>(null);
+
   const { isFocused } = useSearchStore();
 
   const setPlaces = usePlaceStore((state) => state.setPlaces);
+
+  const { setUserLatLng } = useMapStore(
+    useShallow((state) => ({
+      setUserLatLng: state.setUserLatLng,
+    }))
+  );
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['places'],
     queryFn: fetchPlaces,
   });
+
+  /* [useEffect] 위치 변경 감지 시작 */
+  useEffect(() => {
+    watchIdRef.current = watchUserLocation(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        console.log(latitude, longitude);
+        setUserLatLng({ lat: latitude, lng: longitude });
+      },
+      (error) => {
+        alert('사용자의 현재 위치를 불러올 수 없습니다.');
+        console.error('위치 추적 중 에러 발생:', error.message);
+      }
+    );
+
+    return () => {
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     if (data) {
       setPlaces(data);

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -36,7 +36,8 @@ const Solmap: React.FC = () => {
     watchIdRef.current = watchUserLocation(
       (position) => {
         const { latitude, longitude } = position.coords;
-        setUserLatLng({ lat: latitude, lng: longitude });
+        // setUserLatLng({ lat: latitude, lng: longitude }); // [원본 코드]
+        setUserLatLng({ lat: 37.51234, lng: 127.060395 }); // [대체 코드] 만약 본인 주변에 장소가 없다고 나온다면 이것을 주석을 풀어서 사용할 것 / todo : 배포할 때 풀어서 배포하기
       },
       (error) => {
         alert('사용자의 현재 위치를 불러올 수 없습니다.');

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -2,8 +2,8 @@ import { create } from 'zustand';
 import { LatLngType } from '../types';
 
 interface MapState {
-  initCenter: LatLngType;
-  setInitCenter: (center: LatLngType) => void;
+  userLatLng: LatLngType | null;
+  setUserLatLng: (center: LatLngType) => void;
 
   isSearchBounds: boolean;
   setIsSearchBounds: (b: boolean) => void;
@@ -16,11 +16,8 @@ interface MapState {
 }
 
 export const useMapStore = create<MapState>((set) => ({
-  initCenter: {
-    lat: 37.5666805, // 기본 좌표 (서울 시청)
-    lng: 126.9784147,
-  },
-  setInitCenter: (latlng) => set({ initCenter: latlng }),
+  userLatLng: null,
+  setUserLatLng: (latlng) => set({ userLatLng: latlng }),
 
   isSearchBounds: false,
   setIsSearchBounds: (b) => set({ isSearchBounds: b }),

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -25,6 +25,6 @@ export const useMapStore = create<MapState>((set) => ({
   lastBounds: undefined,
   setLastBounds: (bounds) => set({ lastBounds: bounds }),
 
-  lastZoom: 16,
+  lastZoom: 15,
   setLastZoom: (zoom) => set({ lastZoom: zoom }),
 }));

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -16,7 +16,7 @@ interface MapState {
 }
 
 export const useMapStore = create<MapState>((set) => ({
-  userLatLng: null,
+  userLatLng: { lat: 37.5666805, lng: 126.9784147 }, // 유저 기본 좌표 : 서울 시청
   setUserLatLng: (latlng) => set({ userLatLng: latlng }),
 
   isSearchBounds: false,

--- a/src/store/markerStore.ts
+++ b/src/store/markerStore.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand';
 
 interface markerState {
+  markerIdList: number[];
+  setMarkerIdList: (list: number[]) => void;
+
   newMarkerObjectList: naver.maps.Marker[] | null;
   setNewMarkerObjectList: (markers: naver.maps.Marker[] | null) => void;
 
@@ -9,6 +12,9 @@ interface markerState {
 }
 
 export const useMarkerStore = create<markerState>()((set, get) => ({
+  markerIdList: [],
+  setMarkerIdList: (list) => set({ markerIdList: list }),
+
   newMarkerObjectList: null,
   setNewMarkerObjectList: (markers) => {
     const current = get().newMarkerObjectList;

--- a/src/store/markerStore.ts
+++ b/src/store/markerStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 
 interface markerState {
-  markerIdList: number[];
-  setMarkerIdList: (list: number[]) => void;
+  markerIdList: number[] | null;
+  setMarkerIdList: (list: number[] | null) => void;
 
   newMarkerObjectList: naver.maps.Marker[] | null;
   setNewMarkerObjectList: (markers: naver.maps.Marker[] | null) => void;
@@ -12,7 +12,7 @@ interface markerState {
 }
 
 export const useMarkerStore = create<markerState>()((set, get) => ({
-  markerIdList: [],
+  markerIdList: null,
   setMarkerIdList: (list) => set({ markerIdList: list }),
 
   newMarkerObjectList: null,

--- a/src/store/placeStore.ts
+++ b/src/store/placeStore.ts
@@ -7,7 +7,7 @@ interface PlaceStore {
   selectedPlace: Place | null;
   selectedCategory: string | null;
   setPlaces: (places: Place[]) => void;
-  setCategory: (category: string) => void;
+  setCategory: (category: string | null) => void;
   clearCategory: () => void;
   setPlace: (place: Place) => void;
 }
@@ -16,7 +16,7 @@ export const usePlaceStore = create<PlaceStore>((set, get) => ({
   places: [],
   filteredPlaces: [],
   selectedCategory: null,
-  selectedPlace:null,
+  selectedPlace: null,
 
   setPlaces: (places) => set({ places: places, filteredPlaces: places }),
   setCategory: (category) => {
@@ -42,7 +42,7 @@ export const usePlaceStore = create<PlaceStore>((set, get) => ({
       filteredPlaces: state.places,
     }));
   },
-  setPlace: (place) =>{
-    set({selectedPlace: place});
-  }
+  setPlace: (place) => {
+    set({ selectedPlace: place });
+  },
 }));

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -13,6 +13,9 @@ interface SearchState {
 
   selectedRegion: string;
   setSelectedRegion: (value: string) => void;
+
+  relatedPlaceIdList: number[];
+  setRelatedPlaceIdList: (list: number[]) => void;
 }
 
 export const useSearchStore = create<SearchState>((set) => ({
@@ -27,4 +30,7 @@ export const useSearchStore = create<SearchState>((set) => ({
 
   selectedRegion: '',
   setSelectedRegion: (value) => set({ selectedRegion: value }),
+
+  relatedPlaceIdList: [],
+  setRelatedPlaceIdList: (value) => set({ relatedPlaceIdList: value }),
 }));

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -10,6 +10,9 @@ interface SearchState {
 
   relatedSearchList: RelatedSearchWord[];
   setRelatedSearchList: (list: RelatedSearchWord[]) => void;
+
+  selectedRegion: string;
+  setSelectedRegion: (value: string) => void;
 }
 
 export const useSearchStore = create<SearchState>((set) => ({
@@ -21,4 +24,7 @@ export const useSearchStore = create<SearchState>((set) => ({
 
   relatedSearchList: [],
   setRelatedSearchList: (list) => set({ relatedSearchList: list }),
+
+  selectedRegion: '',
+  setSelectedRegion: (value) => set({ selectedRegion: value }),
 }));

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,27 +1,23 @@
-import { LatLngType } from '../types';
-
 // 유저의 현재 위치를 반환하는 함수
-// (지금은 사용자의 현재 좌표를 서울 지역으로 하드코딩)
-export const getUserLocation = async (): Promise<LatLngType> => {
-  try {
-    // const position = await new Promise<GeolocationPosition>((res, rej) => {
-    //   navigator.geolocation.getCurrentPosition(res, rej);
-    // });
-    // return new naver.maps.LatLng(position.coords.latitude, position.coords.latitude);
-    return { lat: 37.51234, lng: 127.060395 };
-  } catch {
-    return { lat: 37.5666805, lng: 126.9784147 }; // 기본 좌표 (서울 시청)
-  }
-};
+// export const getUserLocation = async (): Promise<LatLngType> => {
+//   try {
+//     const position = await new Promise<GeolocationPosition>((res, rej) => {
+//       navigator.geolocation.getCurrentPosition(res, rej);
+//     });
+//     return { lat: position.coords.latitude, lng: position.coords.latitude };
+//   } catch {
+//     return { lat: 37.5666805, lng: 126.9784147 }; // 기본 좌표 (서울 시청)
+//   }
+// };
 
 // 위치 변경 감지 함수
-// export const watchUserLocation = (
-//   onSuccess: (pos: GeolocationPosition) => void,
-//   onError?: (err: GeolocationPositionError) => void
-// ): number | null => {
-//   if (!navigator.geolocation) return null;
+export const watchUserLocation = (
+  onSuccess: (pos: GeolocationPosition) => void,
+  onError?: (err: GeolocationPositionError) => void
+): number | null => {
+  if (!navigator.geolocation) return null;
 
-//   return navigator.geolocation.watchPosition(onSuccess, onError, {
-//     enableHighAccuracy: true,
-//   });
-// };
+  return navigator.geolocation.watchPosition(onSuccess, onError, {
+    enableHighAccuracy: true,
+  });
+};

--- a/src/utils/icon.ts
+++ b/src/utils/icon.ts
@@ -15,6 +15,7 @@ import CultureFill from '../assets/category-icons/cultureFill.svg?react';
 import ShopFill from '../assets/category-icons/shopFill.svg?react';
 import WalkFill from '../assets/category-icons/walkFill.svg?react';
 import WorkFill from '../assets/category-icons/workFill.svg?react';
+import Location from '../assets/locationFill.svg?react';
 
 import FoodBlack from '../assets/category-icons/foodBlack.svg?react';
 import CafeBlack from '../assets/category-icons/cafeBlack.svg?react';
@@ -85,4 +86,19 @@ export const IconMarkerMap: Record<string, string> = {
   shop: ShopMarker,
   walk: WalkMarker,
   work: WorkMarker,
+};
+
+export const iconRelatedSearch: Record<
+  string,
+  React.FC<React.SVGProps<SVGSVGElement>>
+> = {
+  food: FoodFill,
+  cafe: CafeFill,
+  drink: DrinkFill,
+  entertainment: EntertainmentFill,
+  culture: CultureFill,
+  shop: ShopFill,
+  walk: WalkFill,
+  work: WorkFill,
+  location: Location,
 };

--- a/src/utils/mapFunc.ts
+++ b/src/utils/mapFunc.ts
@@ -4,11 +4,14 @@ import { IconMarkerMap } from './icon';
 // 마커를 객체로 생성 후 반환 (마커의 id List도 별도로 반환)
 export const createMarkerObjectList = (
   markers: MarkerInfoType[] | null
-): { objectList: naver.maps.Marker[]; idList: number[] } | null => {
+): {
+  objectList: naver.maps.Marker[] | null;
+  idList: number[] | null;
+} | null => {
   if (!markers || markers.length === 0) return null;
 
-  const objectList: naver.maps.Marker[] = [];
-  const idList: number[] = [];
+  const objectList: naver.maps.Marker[] | null = [];
+  const idList: number[] | null = [];
 
   markers?.forEach((m: MarkerInfoType) => {
     const position = new naver.maps.LatLng(m.latitude, m.longitude);

--- a/src/utils/mapFunc.ts
+++ b/src/utils/mapFunc.ts
@@ -3,15 +3,15 @@ import { IconMarkerMap } from './icon';
 
 // 마커를 객체로 생성 후 반환 (마커의 id List도 별도로 반환)
 export const createMarkerObjectList = (
-  markers: MarkerInfoType[] | null
+  markers: MarkerInfoType[]
 ): {
-  objectList: naver.maps.Marker[] | null;
-  idList: number[] | null;
-} | null => {
-  if (!markers || markers.length === 0) return null;
+  objectList: naver.maps.Marker[];
+  idList: number[];
+} => {
+  const objectList: naver.maps.Marker[] = [];
+  const idList: number[] = [];
 
-  const objectList: naver.maps.Marker[] | null = [];
-  const idList: number[] | null = [];
+  if (!markers || markers.length === 0) return { objectList, idList };
 
   markers?.forEach((m: MarkerInfoType) => {
     const position = new naver.maps.LatLng(m.latitude, m.longitude);
@@ -31,9 +31,9 @@ export const createMarkerObjectList = (
 
 // 마커 객체 바운드 생성 후 반환 함수
 export const createMarkersBounds = (
-  objectList: naver.maps.Marker[] | null
+  objectList: naver.maps.Marker[]
 ): naver.maps.Bounds | undefined => {
-  if (!objectList) return;
+  if (!objectList.length) return;
 
   const bounds = new naver.maps.LatLngBounds(
     new naver.maps.LatLng(0, 0),

--- a/src/utils/mapFunc.ts
+++ b/src/utils/mapFunc.ts
@@ -1,13 +1,15 @@
 import { MarkerInfoType } from '../types';
 import { IconMarkerMap } from './icon';
 
-// 마커를 객체로 생성 후 반환
+// 마커를 객체로 생성 후 반환 (마커의 id List도 별도로 반환)
 export const createMarkerObjectList = (
   markers: MarkerInfoType[] | null
-): naver.maps.Marker[] | null => {
+): { objectList: naver.maps.Marker[]; idList: number[] } | null => {
   if (!markers || markers.length === 0) return null;
 
   const objectList: naver.maps.Marker[] = [];
+  const idList: number[] = [];
+
   markers?.forEach((m: MarkerInfoType) => {
     const position = new naver.maps.LatLng(m.latitude, m.longitude);
     const icon = IconMarkerMap[m.category];
@@ -18,9 +20,10 @@ export const createMarkerObjectList = (
       },
     });
     objectList.push(marker);
+    idList.push(m.id);
   });
 
-  return objectList;
+  return { objectList, idList };
 };
 
 // 마커 객체 바운드 생성 후 반환 함수

--- a/src/utils/placeFunc.ts
+++ b/src/utils/placeFunc.ts
@@ -1,0 +1,23 @@
+import { RelatedSearchWord } from '../types';
+
+/* wordList에 '지역명'만 있으면 최상단 지역명 반환,
+ * wordList에 '지역명+장소명' or '장소명' 있으면 장소 id 리스트 반환
+ */
+export const extractRegionOrPlaceIds = (wordList: RelatedSearchWord[]) => {
+  const placeIdList: number[] = [];
+  wordList.filter((word) => {
+    if (word.type === 'PLACE') {
+      placeIdList.push(word.id!);
+    }
+  });
+
+  // 최상단 지역명 반환
+  if (!placeIdList.length) {
+    const index: number = wordList.findIndex((i) => i.type === 'DISTRICT');
+    const firstRegion: string = wordList[index].name;
+    return firstRegion;
+  }
+
+  // 장소 id 리스트 반환
+  return placeIdList;
+};


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#133 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
쏠맵에서 지도에 표시할 마커와 PreviewContentList, DetailContent에 표시할 데이터를 서버로부터 받아올 수 있도록 api를 연결했습니다.
작업 내용이 많은데 아래 표로 각 커밋의 주요 내용을 정리해봤습니다. 자세한 내용은 커밋 메시지를 참고해주세요. 코드 변경 내역은 'feat/#133' 브랜치를 로컬에 받아서 커밋별 파일 변경 내역을 vscode 로 확인하는 것이 눈에 더 잘 들어옵니다.

| Commit | Commit Title | Description |
|--------|--------------|-------------|
| b667b34 | [feat/#133] 마커 클릭시 상세 정보 조회 | (필요 없는 커밋) |
| 33ff0cf | [fix/#133] 마커 클릭시 상세정보 화면으로 이동 및 api 호출 | 화면에 보이는 마커를 클릭하면 해당 마커의 상세 페이지로 이동함. |
| 5eeeb85 | [refactor/#133] 사용자의 실시간 위치 추적 로직으로 변경 및 관련 코드 정리 | 사용자의 위치를 실시간으로 받아오는 함수를 작성하여 solmap.tsx에서 호출함. |
| d427583 | [fix/#133] 마커 재검색 시 결과가 없을 경우 이전 마커가 남아있는 오류 수정 | '이 지역에서 검색' 버튼 클릭시 결과가 없을 때, 지도에 표시 되어있는 이전 마커는 지우고 결과 없음을 반영하도록 수정함. |
| 885935f | [feat/#133] 검색 결과 없을 때 사용자 거리 기반 추천 API 연동 및 콘솔 출력 | 검색창에서 검색 결과가 없을 때 PreviewContentEmpty.tsx로 이동하게 되는데, 이 페이지에서 '추천 장소 리스트 api'를 호출하여 콘솔에 출력하도록 함. |
| 31ce6d7 | [feat/#133] 연관 검색어 '지역' 클릭 시 해당 지역 마커 표시 및 거리 계산 방식 개선 | 검색창에서 연관검색어 중 '지역명'을 클릭했을 때, PreviewContentList.tsx로 이동하여 '지역명 장소 리스트 api'를 호출하여 콘솔에 출력하도록 함. |
| b896501 | [refactor/#133] 연관 검색어 '지역' 클릭 시 마커 로직을 MapSheet.tsx로 이동 및 지역 상태 | 마커 관련 api 호출을 MapSheet.tsx에서 처리하도록 수정함. |
| 1d69dff | [refactor/#133] 실시간 위치 추적 함수 호출을 solmap.tsx에 유지하고 개발 편의를 위해 위치 하드코딩 | 개발 중 편의를 위해 solmap.tsx에서 호출되고 있는 사용자 위치 실시간 추적 좌표를 하드코딩 함. 배포시에는 하드코딩을 삭제해야함. |
| c2311bb | [feat/#133] 지역 기반 장소 검색 API 연동 및 쿼리 타입 분기 처리 | PreviewContentList.tsx에서 queryType(쿼리 파라미터)의 값이 region일 때 '지역명 장소 리스트 api'를 호출하도록 수정함. |
| 8c5a443 | [refactor/#133] 지도 초기 zoom level을 16에서 15로 변경 | (생략) |
| 598d970 | [chore/#133] 콘솔 메시지 명확화를 위한 로그 텍스트 수정 | (생략) |
| db37451 | [fix/#133] 검색 결과 없음 페이지 이동 시 이전 마커 및 지역 정보 초기화 | 검색창에서 검색 결과가 없을 때 PreviewContentEmpty.tsx로 이동하게 되는데, 이때 기존 정보가 '검색 결과 없음'에 영향받지 않도록 하기 위해서 선택된 지역(selectedRegion), 마커 ID 목록(markerIdList), 마커 객체 리스트(newMarkerObjectList)를 초기화함. |
| 3e4e560 | [refactor/#133] createMarkerObjectList 반환값을 빈 배열로 통일하고 초기 로딩 조건 분기 처리 | 마커 객체 리스트(newMarkerObjectList)의 초기값(null)과 객체 리스트 없음(빈 배열)을 구분하기 위해서, 마커 객체 리스트를 생성하는 함수 createMarkerObjectList가 값이 없을 때 null이 아닌 빈 배열([])을 반환하도록 수정함. |
| 1a13b74 | [feat/#133] 검색창에서 특정 장소 클릭 시 디테일뷰로 이동 및 마커 표시 방식 분기 처리 | 검색창에서 특정 장소를 클릭했을 때 (화면은 DetailContent.tsx로 이동함), 마커를 그리는 로직은, MapSheet.tsx에서 detailType(쿼리 파라미터)의 값이 searching일 때 마커를 새롭게 그리도록 함. 이렇게 detailType로 분기처리한 이유는, 특정 장소 검색을 통해 DetailContent.tsx로 이동하면 마커를 그것만 표시해야하지만, 여러개의 마커 중 하나를 클릭하거나 프리뷰 리스트에서 한 장소를 선택하여 DetailContent.tsx로 이동하는 경우에는 새로운 마커를 추가하면 안되기 때문. |
| 2727da8 | [feat/#133] 지역명만 검색된 경우 최상단 지역을 기반으로 PreviewContentList.tsx로 라우팅 | 검색창에서 연관검색어가 모두 '지역명'인 경우에 사용자가 enter를 하면, (queryType은 region) 최상단 지역에 포함된 장소 리스트가 PreviewContentList.tsx의 콘솔에 출력됨. |
| 007f6ff | [feat/#133] 장소 ID 기반 프리뷰 리스트 조회 및 쿼리 파라미터 처리 개선 | 검색창에서 연관검색어에 '장소'가 1개 이상인 경우에 사용자가 enter를 하면, (queryType은 idList) '장소 id 리스트'가 PreviewContentList.tsx의 콘솔에 출력됨. extractRegionOrPlaceIds 함수는 '지역명(queryType값이 region)' 또는 '장소 id 리스트(queryType값이 idList)'를 반환함. |
| 60cf252 | [feat/#133] 장소 ID 기반 마커 조회 및 쿼리 파라미터 처리 개선 | MapSheet.tsx에서 queryType이 'idList'일 때 '장소 id 리스트로 마커 리스트 api'를 호출하도록 구현함. |
| 22cfcf6 | [feat/#133] 카테고리 선택 시 category 기반 장소 리스트 조회 API 연동 | CategoryButton.tsx와 MapChip.tsx에서 카테고리를 선택하면 queryType 쿼리 파라미터 값을 'category'로 설정하여 PreviewContentList.tsx 화면으로 이동하도록 함. PreviewContentList.tsx에서는 (queryType은 category) '현재 지도 화면 기준으로 선택된 카테고리에 해당하는 장소 리스트' api를 콘솔에 출력하도록 함. |
| 20f639a | [feat/#133] 카테고리 선택 시 해당 카테고리 마커를 지도에 표시하도록 구현 | MapSheet.tsx에서 queryType이 'category'일 때 '현재 지도 화면 기준으로 선택된 카테고리에 해당하는 마커 리스트' api'를 호출하도록 구현함. |
| d131398 | [refactor/#133] '이 지역에서 검색' 클릭 시 선택된 카테고리의 마커만 표시되도록 수정 | 카테고리가 선택된 상태에서 MapSheet.tsx의 '이 지역에서 검색' 버튼 클릭시, 해당 카테고리의 마커만 지도에 표시될 수 있도록, callback 의존성 배열에 lastBounds, selectedCategory를 추가함. |
| 29f838a | [feat/#133] 최근 검색어 클릭 시 연관 검색어 API 호출 및 결과 분기 처리 + 추출 함수 모듈화 | 최근 검색어 클릭시 '연관검색어' api에 보내서 type 및 갯수에 따른 분기처리 진행. |
| c8b6e23 | [refactor/#133] 검색 흐름에 따라 setCategory(null) 적용 및 검색어 노출 방식 개선 | 검색창을 통해 검색이 실행되었을 때, setCategory(null)를 호출하여 MapChipList에 잘못된 시각 피드백이 표시되던 문제를 해결하고, 검색 결과에 따른 검색어를 setInputValue에 설정하여 검색어 표시 일관성을 개선함. |


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
사진은 일부 과정만 첨부했습니다.
---
검색창에서 '사' 작성 후 enter
![image](https://github.com/user-attachments/assets/57f5e035-0ef4-49df-a1df-c496dc570aa6)
![image](https://github.com/user-attachments/assets/4e6880bc-78fb-43f3-bf88-684c1430b551)
---
검색창에서 '와이' 작성 후 enter
![image](https://github.com/user-attachments/assets/391b9238-8d35-4f12-aacf-b9f0497879f0)
![image](https://github.com/user-attachments/assets/34abdfdb-80d6-4005-939c-1e6ca965ed17)
---
검색창에서 '삼' 작성 후 enter
![image](https://github.com/user-attachments/assets/facb16a6-eb0d-4eb7-969e-4220e740e78c)
![image](https://github.com/user-attachments/assets/15172f5e-62bd-4e43-9559-2dbda9c7b462)
---
최근 검색어 중 '고양이역 연남점'을 선택
![image](https://github.com/user-attachments/assets/2e854011-7804-45c7-98c7-d59cc4d86e62)
![image](https://github.com/user-attachments/assets/4cb29db3-ea41-48a3-bbf0-bbd965fc8178)
---
최근 검색어 중 '창'을 선택
![image](https://github.com/user-attachments/assets/dcba4c14-2ca0-4bc7-81fd-7ca724e9c216)
![image](https://github.com/user-attachments/assets/d7e868ba-3259-420e-87aa-dcd01f8db131)




<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 추후 작업은 PreviewContentList, DetailContent에 콘솔로 출력해둔 데이터를 BottomSheet에 나타내주시면 됩니다. [노션 페이지](https://www.notion.so/api-205b1c30cf3b80649ad1f972e93af5f0?source=copy_link)에 A부터 G까지 어느 부분에서 작업하면 될지 적어두었습니다. 참고하셔서 'complete api'를 검색하여 주석을 찾고 작업하시면 편하실거에요. 무한 스크롤도 구현해야합니다. 
- solmap.tsx에서 '사용자의 실시간 위치' 하드코딩은 배포할 때 제거 해야합니다. 
- 쏠맵 검색 결과에서 화면에 마커가 표시 안된 것 처럼 보일때가 있는데, 이 상황은 사실, 마커는 지도에 표시 됐는데, 해당 bounds로 이동이 안 된 오류인 것 같더라구요.. 인터렉션을 빠르게 할 때 발생하는 것 같던데 오류 해결해보도록 노력하겠습니다.


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

