### PR TITLE
[refactor/#147] 하드코딩 된 OAuthCallback 주소를 axios 객체 및 ENDPOINT를 이용해 변경

### DIFF
--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -34,4 +34,6 @@ export const ENDPOINT = {
   // solmark
   SOLMARK_SOLLECT: '/api/solmark/sollect',
 
+  //login
+  OAUTH_CALLBACK: (loginType: string) => `/api/auth/login/${loginType}`
 };

--- a/src/auth/OAuthCallback.tsx
+++ b/src/auth/OAuthCallback.tsx
@@ -1,9 +1,10 @@
-import axios from 'axios';
 import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import useAuthStore from '../store/authStore';
 import { useShallow } from 'zustand/shallow';
 import useLocationStore from '../store/locationStore';
+import { publicAxios } from '../api/axios';
+import { ENDPOINT } from '../api/urls';
 
 const OAuthCallback = () => {
   const { search } = useLocation();
@@ -30,15 +31,14 @@ const OAuthCallback = () => {
       console.error('Invalid OAuth callback parameters');
       return;
     }
+    if (!loginType) {
+      console.error('Login type is not specified');
+      return;
+    }
 
-    axios
-      .get(`http://3.34.65.130/api/auth/login/${loginType?.toUpperCase()}`, {
-        params: {
-          code: code,
-        },
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    publicAxios
+      .get(ENDPOINT.OAUTH_CALLBACK(loginType.toUpperCase()), {
+        params: { code },
       })
       .then((response) => {
         const accessToken = response.data.data.accessToken;


### PR DESCRIPTION
ENDPOINT에 OAUTH_CALLBACK 필드를 추가했고, 이를 axios의 publicAxios를 이용해 불러와 기존 하드코딩된 주소를 개선함.

<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#147 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
하드코딩된 OAuthCallback 주소 값을 axios 객체를 이용해 불러옴.

ENDPOINT에 OAUTH_CALLBACK 필드를 추가했고, 이를 axios의 publicAxios를 이용해 불러와 기존 하드코딩된 주소를 개선함.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

