### PR TITLE
Feat/#153 쏠루트 작성 기본 구조 생성

### DIFF
--- a/src/components/Searching/RelatedSearchPlace.tsx
+++ b/src/components/Searching/RelatedSearchPlace.tsx
@@ -10,7 +10,7 @@ import work from '../../assets/category-icons/workFill.svg';
 import location from '../../assets/locationFill.svg';
 import AddSmall from '../../assets/addSmallIcon.svg?react';
 import Check from '../../assets/check.svg?react';
-import { ReleatedSearchPlace } from '../../types';
+import type { RelatedSearchPlace } from '../../types';
 import { useSollectWriteStore } from '../../store/sollectWriteStore';
 import { useShallow } from 'zustand/shallow';
 
@@ -49,7 +49,7 @@ const iconMap: Record<string, string> = {
 };
 
 interface RelatedSearchPlaceProps {
-  relatedSearchPlace: ReleatedSearchPlace;
+  relatedSearchPlace: RelatedSearchPlace;
 }
 
 const RelatedSearchPlace: React.FC<RelatedSearchPlaceProps> = ({

--- a/src/components/Sollect/SollectWrite/SollectWriteAddedPlace.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteAddedPlace.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import DragAndDrap from '../../../assets/dragAndDrop.svg?react';
 import Trash from '../../../assets/trash.svg?react';
-import { ReleatedSearchPlace } from '../../../types';
+import { RelatedSearchPlace } from '../../../types';
 import { iconSmallMap } from '../../../utils/icon';
 
 const SollectWriteAddedPlace: React.FC<{
-  place: ReleatedSearchPlace;
+  place: RelatedSearchPlace;
   handleRemove: (placeId: number | null) => void;
   isDragging?: boolean;
 }> = ({ place, handleRemove, isDragging = false }) => {

--- a/src/components/Sollect/SollectWrite/SollectWriteHeader.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteHeader.tsx
@@ -13,7 +13,7 @@ const SollectWriteHeader: React.FC<SollectWriteHeaderProps> = ({
   onRight,
 }) => {
   return (
-    <div className='w-full h-50 py-4 flex justify-between items-center text-primary-950 text-sm font-normal leading-tight'>
+    <div className='w-full h-50 py-4 flex justify-between items-center text-primary-950 text-sm font-normal leading-tight bg-white'>
       <div
         className='w-42 h-42 pl-16 inline-flex justify-start items-center'
         onClick={onLeft}>

--- a/src/components/Sollect/SollectWrite/SollectWritePlaces.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWritePlaces.tsx
@@ -9,7 +9,7 @@ import {
   DraggableStyle,
 } from '@hello-pangea/dnd';
 import SollectWriteAddedPlace from './SollectWriteAddedPlace';
-import { ReleatedSearchPlace } from '../../../types';
+import { RelatedSearchPlace } from '../../../types';
 
 const PlaceAddButton = () => {
   const navigate = useNavigate();
@@ -36,7 +36,7 @@ const SollectWritePlacese = () => {
   }
 
   const reorder = (
-    list: ReleatedSearchPlace[],
+    list: RelatedSearchPlace[],
     startIndex: number,
     endIndex: number
   ) => {

--- a/src/components/Solroute/SolrouteMap.tsx
+++ b/src/components/Solroute/SolrouteMap.tsx
@@ -1,0 +1,5 @@
+const SolrouteMap: React.FC = () => {
+  return <div className='self-stretch h-214 pt-66 pb-8 bg-primary-100' />;
+};
+
+export default SolrouteMap;

--- a/src/components/Solroute/SolroutePlaceAddButton.tsx
+++ b/src/components/Solroute/SolroutePlaceAddButton.tsx
@@ -1,0 +1,7 @@
+const SolroutePlaceAddButton: React.FC = () => (
+  <div className="w-361 h-48 bg-primary-700 rounded-lg flex justify-center items-center border border-solid border-primary-700">
+    <span className="text-primary-50 text-sm font-medium leading-tight">장소 추가</span>
+  </div>
+);
+
+export default SolroutePlaceAddButton;

--- a/src/components/Solroute/SolrouteTitle.tsx
+++ b/src/components/Solroute/SolrouteTitle.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const SolrouteTile: React.FC = () => {
+  return (
+    <div className="w-full h-50 py-4 flex justify-between items-center text-primary-950 text-sm font-normal leading-tight">
+      <div className="w-42 h-42 pl-16 inline-flex justify-start items-center">
+        <span>Solroute</span>
+      </div>
+      <div className="w-42 h-42 pr-16 inline-flex justify-end items-center">
+        <span>Title</span>
+      </div>
+    </div>
+  );
+};
+
+export default SolrouteTile;

--- a/src/pages/SolrouteWritePage.tsx
+++ b/src/pages/SolrouteWritePage.tsx
@@ -1,0 +1,28 @@
+import SollectWriteHeader from '../components/Sollect/SollectWrite/SollectWriteHeader';
+import SolrouteMap from '../components/Solroute/SolrouteMap';
+import SolroutePlaceAddButton from '../components/Solroute/SolroutePlaceAddButton';
+import SolrouteTile from '../components/Solroute/SolrouteTitle';
+
+const SollectWritePage = () => {
+  return (
+    <div className='w-full h-full flex flex-col relative overflow-hidden'>
+      <div className='fixed top-0 left-0 right-0 z-10 '>
+        <SollectWriteHeader
+          leftText='취소'
+          rightText='등록'
+          onLeft={() => window.history.back()}
+          onRight={() => console.log('완료 버튼 클릭')}
+        />
+      </div>
+      <div className='flex-1 overflow-y-auto mt-50'>
+        <SolrouteTile />
+        <SolrouteMap />
+        <div className='pt-24 pb-48 px-16'>
+          <SolroutePlaceAddButton />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SollectWritePage;

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -18,6 +18,7 @@ import Login from '../pages/Login';
 import SollectWritePage from '../pages/SollectWritePage';
 import SollectWriteLayout from '../layout/SollectWriteLayout';
 import SollectWritePlacePage from '../pages/SollectWritePlacePage';
+import SolrouteWritePage from '../pages/SolrouteWritePage';
 
 const AppRouter = () => {
   const location = useLocation();
@@ -57,6 +58,8 @@ const AppRouter = () => {
         </Route>
         <Route path='/map/reviews/:placeId' element={<ReviewsPage />} />
         <Route path='/sollect/write/search' element={<SearchPage />} />
+
+        <Route path='/solroute/write' element={<SolrouteWritePage />} />
       </Routes>
       {/* Modal Routes */}
       {modal && (

--- a/src/store/sollectWriteStore.ts
+++ b/src/store/sollectWriteStore.ts
@@ -1,6 +1,6 @@
 // src/stores/useSollectWriteStore.ts
 import { create } from 'zustand';
-import { Paragraph, RelatedSearchWord, ReleatedSearchPlace } from '../types';
+import { Paragraph, RelatedSearchWord, RelatedSearchPlace } from '../types';
 
 type SollectWriteState = {
   seq: number;
@@ -9,7 +9,7 @@ type SollectWriteState = {
   title: string | null;
   thumbnail: Paragraph | null;
   paragraphs: Paragraph[];
-  places: ReleatedSearchPlace[]; // 장소 ID 목록을 저장하는 속성 추가
+  places: RelatedSearchPlace[]; // 장소 ID 목록을 저장하는 속성 추가
   setTitle: (title: string | null) => void; // 제목을 설정하는 함수
   setThumbnail: (thumbnail: Paragraph | null) => void; // 썸네일을 설정하는 함수
   addTextParagraph: (afterSeq?: number) => void;

--- a/src/store/solrouteWriteStore.ts
+++ b/src/store/solrouteWriteStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { SolroutePlace } from '../types';
+
+interface SolrouteWriteState {
+  title: string | null;
+  icon: number | null;
+  places: SolroutePlace[]; // 장소 ID 목록을 저장하는 속성
+}
+
+export const useSollectWriteStore = create<SolrouteWriteState>((set) => ({
+  title: null, // 제목을 저장하는 속성
+  places: [], // 장소 ID 목록을 저장하는 속성
+  icon: null, // 아이콘 번호를 저장하는 속성
+
+  setTitle: (title: string | null) => set({ title }),
+  setIcon: (icon: number) => set({ icon }),
+  setPlaces: (places: SolroutePlace[]) => set({ places }),
+}));

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,12 @@ export type RelatedSearchPlace = RelatedSearchWord & {
   isAdded: boolean;
 };
 
+export type SolroutePlace = RelatedSearchPlace & {
+  memo: string;
+  latitude: number;
+  longitude: number;
+};
+
 export type Emoji = 'good' | 'bad' | null;
 
 export type ReviewType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type RelatedSearchWord = {
   type: 'DISTRICT' | 'PLACE';
 };
 
-export type ReleatedSearchPlace = RelatedSearchWord & {
+export type RelatedSearchPlace = RelatedSearchWord & {
   isAdded: boolean;
 };
 


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#153

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
쏠루트 작성 page와 store인 solrouteWritePage를 생성함

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
```
export type RelatedSearchWord = {
  address: string | null;
  category: string | null;
  distance: {
    unit: string;
    value: number;
  };
  id: number | null;
  name: string;
  type: 'DISTRICT' | 'PLACE';
};

export type RelatedSearchPlace = RelatedSearchWord & {
  isAdded: boolean;
};

export type SolroutePlace = RelatedSearchPlace & {
  memo: string;
  latitude: number;
  longitude: number;
};
```

쏠루트 store에 사용할 place 타입으로 SolroutePlace를 만들었습니디다
기존 RelatedSearchPlace에 memo, latitude, longitude를 추가했습니다.
다만 쏠마크의 place와도 연동되어야할 수 있어 추후 변동될 수도 있을 것 같아요!
자유롭게 변동해주셔도 됩니다.

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

