### PR TITLE
Feat/#151 쏠맵 프리뷰, 디테일 페이지

### DIFF
--- a/src/api/placeApi.ts
+++ b/src/api/placeApi.ts
@@ -3,10 +3,7 @@ import { publicAxios } from './axios';
 import qs from 'qs';
 import { ENDPOINT } from './urls';
 
-export const fetchPlaces = async () => {
-  await new Promise((res) => setTimeout(res, 500));
-  return mockPlaces;
-};
+
 
 export const getPlacesByDisplay = async (
   swLat: number, // swY - min
@@ -70,7 +67,7 @@ export const getPlaceByIdList = async (
 
 export const getPlaceDetail = async (id: number) => {
   const res = await publicAxios.get(ENDPOINT.SOLMAP_PLACE_DETAIL + id);
-
+  
   return res.data.data;
 };
 
@@ -88,104 +85,3 @@ export const getPlacesNearby = async (
   return res.data.data;
 };
 
-export const fetchPlaceById = async (id: number) => {
-  // await new Promise((res) => setTimeout(res, 300));
-  return mockPlaces[id];
-};
-
-const mockPlaces: Place[] = [
-  {
-    id: 1,
-    title: '스타벅스 노량진동점',
-    address: '서울 동작구 노량진로 190',
-    latitude: 37.513213,
-    longitude: 126.94656,
-    category: { title: '카페', id: 'cafe' },
-    rating: 4.5,
-    tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'lively', text: '시끌벅적한' },
-      { id: 'cozy', text: '편안한' },
-    ],
-    hours: [
-      { day: 0, startTime: '10:00', endTime: '20:30' },
-      { day: 1, startTime: '10:00', endTime: '20:30' },
-      { day: 2, startTime: '10:00', endTime: '20:30' },
-      { day: 3, startTime: '10:00', endTime: '20:30' },
-      { day: 4, startTime: '10:00', endTime: '20:30' },
-      { day: 5, startTime: '10:00', endTime: '20:30' },
-      { day: 6, startTime: '10:00', endTime: '17:00' },
-    ],
-  },
-
-  {
-    id: 2,
-    title: '도로도로커피숍',
-    address: '서울 동작구 노량진로 145 1층',
-    latitude: 37.51388,
-    longitude: 126.942058,
-    category: { title: '카페', id: 'cafe' },
-    rating: 4.2,
-    tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'lively', text: '시끌벅적한' },
-      { id: 'cozy', text: '편안한' },
-    ],
-    hours: [
-      { day: 0, startTime: '10:00', endTime: '20:30' },
-      { day: 1, startTime: '10:00', endTime: '20:30' },
-      { day: 2, startTime: '10:00', endTime: '20:30' },
-      { day: 3, startTime: '10:00', endTime: '20:30' },
-      { day: 4, startTime: '10:00', endTime: '20:30' },
-      { day: 5, startTime: '10:00', endTime: '20:30' },
-      { day: 6, startTime: '10:00', endTime: '17:00' },
-    ],
-  },
-  {
-    id: 3,
-    title: '미분당',
-    address: '서울 동작구 노량진로 190',
-    latitude: 37.5132,
-    longitude: 126.946,
-    category: { title: '식당', id: 'food' },
-    rating: 4.5,
-    tags: [
-      { id: 'luxurious', text: '고급스러운' },
-      { id: 'unique', text: '색다른' },
-      { id: 'hip', text: '힙한' },
-    ],
-    hours: [
-      { day: 0, startTime: '10:00', endTime: '20:30' },
-      { day: 1, startTime: '10:00', endTime: '20:30' },
-      { day: 2, startTime: '10:00', endTime: '20:30' },
-      { day: 3, startTime: '10:00', endTime: '20:30' },
-      { day: 4, startTime: '10:00', endTime: '20:30' },
-      { day: 5, startTime: '10:00', endTime: '20:30' },
-      { day: 6, startTime: '10:00', endTime: '17:00' },
-    ],
-  },
-
-  {
-    id: 4,
-    title: '샤브로',
-    address: '서울 동작구 노량진로 145 1층',
-    latitude: 37.513,
-    longitude: 126.942,
-    category: { title: '식당', id: 'food' },
-    rating: 4.2,
-    tags: [
-      { id: 'luxurious', text: '고급스러운' },
-      { id: 'unique', text: '색다른' },
-      { id: 'hip', text: '힙한' },
-    ],
-    hours: [
-      { day: 0, startTime: '10:00', endTime: '20:30' },
-      { day: 1, startTime: '10:00', endTime: '20:30' },
-      { day: 2, startTime: '10:00', endTime: '20:30' },
-      { day: 3, startTime: '10:00', endTime: '20:30' },
-      { day: 4, startTime: '10:00', endTime: '20:30' },
-      { day: 5, startTime: '10:00', endTime: '20:30' },
-      { day: 6, startTime: '10:00', endTime: '17:00' },
-    ],
-  },
-];

--- a/src/api/reviewApi.ts
+++ b/src/api/reviewApi.ts
@@ -13,7 +13,7 @@ export const addReview = async (newReview: ReviewType) => {
 
   // Mock adding the review to the database
   mockReviews.push(newReview);
-}
+};
 
 const mockReviews: ReviewType[] = [
   {
@@ -28,11 +28,11 @@ const mockReviews: ReviewType[] = [
   혼자 온 사람들도 많아서 눈치 안 보고 오래 있을 수 있었어요 앞으로도…`,
     images: [],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'luxurious', text: '고급스러운' },
-      { id: 'nature-friendly', text: '자연친화적인' },
-      { id: 'single-seat', text: '1인 좌석이 있는' },
-      { id: 'single-menu', text: '1인 메뉴가 있는' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -51,11 +51,11 @@ const mockReviews: ReviewType[] = [
       'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
     ],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'luxurious', text: '고급스러운' },
-      { id: 'single-seat', text: '1인 좌석이 있는' },
-      { id: 'single-menu', text: '1인 메뉴가 있는' },
-      { id: 'no-tag', text: '태그 없음' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -68,10 +68,11 @@ const mockReviews: ReviewType[] = [
     content: '',
     images: [],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'luxurious', text: '고급스러운' },
-      { id: 'trendy', text: '트렌디한' },
-      { id: 'no-tag', text: '태그 없음' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -87,9 +88,11 @@ const mockReviews: ReviewType[] = [
       'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
     ],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'nature-friendly', text: '자연친화적인' },
-      { id: 'single-seat', text: '1인 좌석이 있는' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -104,8 +107,11 @@ const mockReviews: ReviewType[] = [
       'https://dynamic-media-cdn.tripadvisor.com/media/photo-o/15/cc/5b/8f/various-breads.jpg?w=800&h=-1&s=1',
     ],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'luxurious', text: '고급스러운' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -123,9 +129,11 @@ const mockReviews: ReviewType[] = [
       'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
     ],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'good-for-work', text: '작업하기 좋은' },
-      { id: 'single-menu', text: '1인 메뉴가 있는' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -138,9 +146,11 @@ const mockReviews: ReviewType[] = [
     content: `완전 제 취향의 카페였어요. 음악도 잔잔하고 인테리어도 깔끔!`,
     images: [],
     tags: [
-      { id: 'quiet', text: '조용한' },
-      { id: 'luxurious', text: '고급스러운' },
-      { id: 'trendy', text: '트렌디한' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
   {
@@ -157,9 +167,11 @@ const mockReviews: ReviewType[] = [
       'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
     ],
     tags: [
-      { id: 'trendy', text: '트렌디한' },
-      { id: 'crowded', text: '사람이 많은' },
-      { id: 'no-tag', text: '태그 없음' },
+      '색다른',
+      '힙한',
+      '가볍게 들르기 좋은',
+      '1인 메뉴가 있는',
+      '낮에 가기 좋은',
     ],
   },
 ];

--- a/src/api/sollectApi.ts
+++ b/src/api/sollectApi.ts
@@ -98,6 +98,19 @@ export const fetchRecommendSollect = async (
   }
 };
 
+export const fetchRelatedSollect = async(placeId:number, cursorId:number)=>{
+try{
+  const params = {
+    cursorId:cursorId
+  }
+  const res = await publicAxios.get(ENDPOINT.SOLLECT_RELATED(placeId),{params});
+
+  return res.data.data.contents;
+}catch(e){
+  console.log(e);
+}
+};
+
 
 export const fetchSollectDetail = async(sollectId:number)=>{
   try{

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -34,13 +34,14 @@ export const ENDPOINT = {
     POST: 'api/sollect',
     PUT: (id: number) => `/api/sollect/${id}`,
     DELETE: (id: number) => `/api/sollect/${id}`,
-    GET: (id:number) => `/api/sollect/${id}`
+    GET: (id: number) => `/api/sollect/${id}`,
   },
   SOLLECT_UPLOAD: (id: number) => `/api/sollect/${id}/upload`,
+  SOLLECT_RELATED: (id: number) => `/api/sollect/related/${id}`,
 
   // solmark
   SOLMARK_SOLLECT: '/api/solmark/sollect',
 
   //login
-  OAUTH_CALLBACK: (loginType: string) => `/api/auth/login/${loginType}`
+  OAUTH_CALLBACK: (loginType: string) => `/api/auth/login/${loginType}`,
 };

--- a/src/components/BottomSheet/ContentTitle.tsx
+++ b/src/components/BottomSheet/ContentTitle.tsx
@@ -78,7 +78,7 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
         {/* detail */}
         {isDetail && (
           <div className='flex gap-8'>
-            <SolmarkChip label markCount={place.markedCount}/>
+            <SolmarkChip label markCount={place.markedCount} />
             <div
               className={`${buttonStyle} border border-primary-400`}
               onClick={copyUrl}>
@@ -100,8 +100,8 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
           <div className='flex items-center' onClick={handleShowHoursInfo}>
             <img src={clock} alt='clock' />
             <p>
-              {place.isOpen ? '영업 중' : '영업 종료'} ·{' '}
-              {place.isOpen && place.closingTime && place.closingTime} 영업 종료
+              {place.isOpen ? '영업 중' : '영업 종료'}
+              {place.isOpen && <span> ·{' '}{place.closingTime}영업 종료</span>}
             </p>
             <img
               src={arrow}

--- a/src/components/BottomSheet/ContentTitle.tsx
+++ b/src/components/BottomSheet/ContentTitle.tsx
@@ -38,8 +38,6 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
   const buttonStyle = 'w-32 h-32 rounded-lg flex justify-center items-center';
 
   // 하드코딩
-  const isOpen = true;
-  const closingTime = '22:30';
   const [degree, setDegree] = useState(90);
 
   const handleShowHoursInfo = () => {
@@ -61,14 +59,14 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
         {/* left */}
         <div className='inline-flex items-center'>
           <span className='text-lg leading-relaxed text-primary-900 font-bold pr-4'>
-            {place.title}
+            {place.name}
           </span>
           <span className='text-sm text-primary-400 pr-12'>
-            {place.category.title}
+            {place.detailedCategory}
           </span>
           {isPreview && (
             <span className='text-sm text-primary-900 font-semibold'>
-              영업 중
+              {place.isOpen ? '영업 중' : '영업 종료'}
             </span>
           )}
         </div>
@@ -80,7 +78,7 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
         {/* detail */}
         {isDetail && (
           <div className='flex gap-8'>
-            <SolmarkChip label />
+            <SolmarkChip label markCount={place.markedCount}/>
             <div
               className={`${buttonStyle} border border-primary-400`}
               onClick={copyUrl}>
@@ -102,28 +100,30 @@ const ContentTitle: React.FC<ContentTitleProps> = ({ place, property }) => {
           <div className='flex items-center' onClick={handleShowHoursInfo}>
             <img src={clock} alt='clock' />
             <p>
-              {isOpen ? '영업 중' : '영업 종료'} · {closingTime} 영업 종료
+              {place.isOpen ? '영업 중' : '영업 종료'} ·{' '}
+              {place.isOpen && place.closingTime && place.closingTime} 영업 종료
             </p>
             <img
               src={arrow}
               alt='arrow'
               className='w-20 h-20'
-              style={{transform:`rotate(${degree}deg)`}}
+              style={{ transform: `rotate(${degree}deg)` }}
             />
           </div>
 
           {showHoursInfo && (
             <div className='px-24 py-6'>
               <ul>
-                {place.hours.map((hour) => {
-                  return (
-                    <p className='text-primary-950 text-sm'>
-                      {days[hour.day]}{' '}
-                      <span className='text-primary-400'>·</span>{' '}
-                      {hour.startTime} ~ {hour.endTime}
-                    </p>
-                  );
-                })}
+                {place.openingHours &&
+                  place.openingHours.map((hour) => {
+                    return (
+                      <p className='text-primary-950 text-sm'>
+                        {days[hour.dayOfWeek]}{' '}
+                        <span className='text-primary-400'>·</span>{' '}
+                        {hour.startTime} ~ {hour.endTime}
+                      </p>
+                    );
+                  })}
               </ul>
             </div>
           )}

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -61,7 +61,7 @@ const DetailContent: React.FC = () => {
       {/* 관련 쏠렉트 보기 */}
       <Link
         className='flex text-primary-950 text-xs pl-16 mb-12'
-        to='/related-sollect'>
+        to={`/related-sollect/${placeId}`}>
         관련 쏠렉트 보기 <img src={arrow} alt='arrow' />
       </Link>
 

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -4,7 +4,7 @@ import ReviewRange from './ReviewRange';
 import TagList from './TagList';
 import ReviewPhotos from './ReviewPhotos';
 import ReviewList from './Review/ReviewList';
-import { fetchPlaceById, getPlaceByIdList, getPlaceDetail } from '../../api/placeApi';
+import { getPlaceByIdList, getPlaceDetail } from '../../api/placeApi';
 import { usePlaceStore } from '../../store/placeStore';
 import { Link, useParams } from 'react-router-dom';
 import arrow from '../../assets/arrow.svg';
@@ -12,6 +12,8 @@ import { useQuery } from '@tanstack/react-query';
 
 const DetailContent: React.FC = () => {
   const { placeId } = useParams<{ placeId: string }>();
+    const { selectedPlace, setPlace } = usePlaceStore();
+
 
   const { data } = useQuery({
     queryKey: ['placeDetail', placeId],
@@ -28,9 +30,7 @@ const DetailContent: React.FC = () => {
     }
   }, [data]);
 
-  const { selectedPlace } = usePlaceStore();
 
-  const { setPlace } = usePlaceStore();
 
   const images = [
     'https://images.ctfassets.net/rric2f17v78a/1ql70crfzaiw9nFd58CZ7p/04652a19ab2fe5a5370d92c7957eb016/open-a-bakery-header.jpg',
@@ -57,11 +57,11 @@ const DetailContent: React.FC = () => {
       <div className='pb-12'>
         <TagList
           headerName='분위기'
-          detailTags={selectedPlace.mood}
+          detailTags={selectedPlace.tags.mood}
         />
         <TagList
           headerName='1인 이용'
-          detailTags={selectedPlace.solo}
+          detailTags={selectedPlace.tags.solo}
         />
       </div>
 

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -4,7 +4,7 @@ import ReviewRange from './ReviewRange';
 import TagList from './TagList';
 import ReviewPhotos from './ReviewPhotos';
 import ReviewList from './Review/ReviewList';
-import { fetchPlaceById, getPlaceDetail } from '../../api/placeApi';
+import { fetchPlaceById, getPlaceByIdList, getPlaceDetail } from '../../api/placeApi';
 import { usePlaceStore } from '../../store/placeStore';
 import { Link, useParams } from 'react-router-dom';
 import arrow from '../../assets/arrow.svg';
@@ -22,11 +22,13 @@ const DetailContent: React.FC = () => {
   // complete api: 마커 클릭시 해당 장소 상세정보 호출
   // complete api: 검색 결과에서 특정 장소 클릭시 상세 정보 호출
   useEffect(() => {
-    console.log('placeDetail:', data);
+    if(data){
+      console.log('placeDetail:', data);
+      setPlace(data.place);
+    }
   }, [data]);
 
   const { selectedPlace } = usePlaceStore();
-  const counts = [2, 3, 1];
 
   const { setPlace } = usePlaceStore();
 
@@ -37,13 +39,7 @@ const DetailContent: React.FC = () => {
     'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
   ];
 
-  useEffect(() => {
-    if (placeId) {
-      fetchPlaceById(parseInt(placeId)).then((fetchedPlace) => {
-        setPlace(fetchedPlace);
-      });
-    }
-  }, [placeId]);
+
 
   if (!selectedPlace) {
     return null;
@@ -55,19 +51,17 @@ const DetailContent: React.FC = () => {
       <ContentTitle place={selectedPlace} property='detail' />
 
       {/* ReviewRange */}
-      <ReviewRange rating={selectedPlace.rating} recommend={90} />
+      <ReviewRange rating={selectedPlace.rating} recommend={selectedPlace.isSoloRecommended} />
 
       {/* tags */}
       <div className='pb-12'>
         <TagList
           headerName='분위기'
-          tags={selectedPlace.tags}
-          counts={counts}
+          detailTags={selectedPlace.mood}
         />
         <TagList
           headerName='1인 이용'
-          tags={selectedPlace.tags}
-          counts={counts}
+          detailTags={selectedPlace.solo}
         />
       </div>
 
@@ -82,12 +76,13 @@ const DetailContent: React.FC = () => {
       </Link>
 
       {/* ReviewList */}
-      {placeId && (
+      
+      {/* {placeId && (
         <ReviewList
           placeId={parseInt(placeId)}
-          placeName={selectedPlace.title}
+          placeName={selectedPlace.name}
         />
-      )}
+      )} */}
     </div>
   );
 };

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -4,7 +4,7 @@ import ReviewRange from './ReviewRange';
 import TagList from './TagList';
 import ReviewPhotos from './ReviewPhotos';
 import ReviewList from './Review/ReviewList';
-import { getPlaceByIdList, getPlaceDetail } from '../../api/placeApi';
+import { getPlaceDetail } from '../../api/placeApi';
 import { usePlaceStore } from '../../store/placeStore';
 import { Link, useParams } from 'react-router-dom';
 import arrow from '../../assets/arrow.svg';

--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -31,16 +31,6 @@ const DetailContent: React.FC = () => {
   }, [data]);
 
 
-
-  const images = [
-    'https://images.ctfassets.net/rric2f17v78a/1ql70crfzaiw9nFd58CZ7p/04652a19ab2fe5a5370d92c7957eb016/open-a-bakery-header.jpg',
-    'https://i.namu.wiki/i/PgSYmu9y55E5YicKvIK14P0ttQUQG4ioSn-Fd6u27a0r2Jeu02fJAYRkmf2qtOb6fHLBnlrLeXu_gSESQbmykg.webp',
-    'https://dynamic-media-cdn.tripadvisor.com/media/photo-o/15/cc/5b/8f/various-breads.jpg?w=800&h=-1&s=1',
-    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvcP45F8yq6R7WMSjpuU0JAOh0foZEOSPr9g&s',
-  ];
-
-
-
   if (!selectedPlace) {
     return null;
   }
@@ -66,7 +56,7 @@ const DetailContent: React.FC = () => {
       </div>
 
       {/* ReviewPhotoList */}
-      <ReviewPhotos images={images} more />
+      <ReviewPhotos images={selectedPlace.thumbnailUrl} more />
 
       {/* 관련 쏠렉트 보기 */}
       <Link
@@ -77,12 +67,12 @@ const DetailContent: React.FC = () => {
 
       {/* ReviewList */}
       
-      {/* {placeId && (
+      {placeId && (
         <ReviewList
           placeId={parseInt(placeId)}
           placeName={selectedPlace.name}
         />
-      )} */}
+      )}
     </div>
   );
 };

--- a/src/components/BottomSheet/Preview/PreviewContent.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContent.tsx
@@ -29,7 +29,7 @@ const PreviewContent:React.FC<PreviewContentProps> = ({place}) => {
       <ContentTitle place={place} property='preview'/>
 
       {/* review range */}
-      <ReviewRange rating={place.rating} recommend={90}/>
+      <ReviewRange rating={place.rating} recommend={place.isSoloRecommended}/>
 
       {/* tag list */}
       <TagList tags={place.tags}/>

--- a/src/components/BottomSheet/Preview/PreviewContent.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContent.tsx
@@ -1,44 +1,37 @@
-import React from 'react'
-import { Place } from '../../../types';
+import React from 'react';
 import ContentTitle from '../ContentTitle';
 import ReviewRange from '../ReviewRange';
 import TagList from '../TagList';
 import PreviewPhotos from './PreviewPhotos';
 import { useNavigate } from 'react-router-dom';
+import { PreviewPlace } from '../../../types';
 
-interface PreviewContentProps{
-  place:Place
+interface PreviewContentProps {
+  place: PreviewPlace;
 }
 
-const PreviewContent:React.FC<PreviewContentProps> = ({place}) => {
+const PreviewContent: React.FC<PreviewContentProps> = ({ place }) => {
   const navigate = useNavigate();
 
-  const images = [
-    "https://images.ctfassets.net/rric2f17v78a/1ql70crfzaiw9nFd58CZ7p/04652a19ab2fe5a5370d92c7957eb016/open-a-bakery-header.jpg",
-    "https://i.namu.wiki/i/PgSYmu9y55E5YicKvIK14P0ttQUQG4ioSn-Fd6u27a0r2Jeu02fJAYRkmf2qtOb6fHLBnlrLeXu_gSESQbmykg.webp",
-    "https://dynamic-media-cdn.tripadvisor.com/media/photo-o/15/cc/5b/8f/various-breads.jpg?w=800&h=-1&s=1"
-  ];
-
-  const handleClick = ()=>{
+  const handleClick = () => {
     navigate(`/map/detail/${place.id}`, { state: { from: 'preview' } });
-  } 
+  };
 
   return (
     <div className='border-b border-primary-100 pt-12' onClick={handleClick}>
       {/* content title */}
-      <ContentTitle place={place} property='preview'/>
+      <ContentTitle place={place} property='preview' />
 
       {/* review range */}
-      <ReviewRange rating={place.rating} recommend={place.isSoloRecommended}/>
+      <ReviewRange rating={place.rating} recommend={place.isSoloRecommended} />
 
       {/* tag list */}
-      <TagList tags={place.tags}/>
+      <TagList tags={place.tags} />
 
       {/* Preview photos */}
-      <PreviewPhotos images={images}/>
-      
+      <PreviewPhotos images={place.thumbnailUrls} />
     </div>
   );
-}
+};
 
-export default PreviewContent
+export default PreviewContent;

--- a/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentEmpty.tsx
@@ -6,7 +6,7 @@ import { useMapStore } from '../../../store/mapStore';
 import { getPlacesNearby } from '../../../api/placeApi';
 
 const PreviewContentEmpty: React.FC = () => {
-  const filteredPlaces = usePlaceStore((state) => state.filteredPlaces);
+  const {recommendedPlaces, setRecommendedPlaces} = usePlaceStore();
 
   const { userLatLng } = useMapStore();
 
@@ -19,6 +19,9 @@ const PreviewContentEmpty: React.FC = () => {
   // complete api: 검색결과 없을 시 유저 위치 기반 거리순 추천 장소 리스트 호출
   useEffect(() => {
     console.log('placeRecommanded:', data);
+    if(data){
+      setRecommendedPlaces(data.places);
+    }
   }, [data]);
 
   return (
@@ -40,8 +43,8 @@ const PreviewContentEmpty: React.FC = () => {
       </div>
 
       <div>
-        {filteredPlaces.map((place) => (
-          <PreviewContent key={place.title} place={place} />
+        {recommendedPlaces.map((place) => (
+          <PreviewContent key={place.name} place={place} />
         ))}
       </div>
     </div>

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -64,8 +64,8 @@ const PreviewContentList: React.FC = () => {
 
   // complete api: 지역 이름으로 프리뷰 리스트 호출 api
   useEffect(() => {
-    console.log('places[Region]Query:', placesRegionQuery.data);
     if (placesRegionQuery.data) {
+      console.log('places[Region]Query:', placesRegionQuery.data.places);
       setPlaces(placesRegionQuery.data.places);
     }
   }, [placesRegionQuery.data, setPlaces]);

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -46,21 +46,25 @@ const PreviewContentList: React.FC = () => {
 
   const placesRegionQuery = useInfiniteQuery({
     queryKey: ['placesRegion', selectedCategory],
-    queryFn: ({ pageParam = undefined }) =>
+    queryFn: ({ pageParam = {cursorId:undefined, cursorDist:undefined} }) =>
       getPlacesByRegion(
         selectedRegion,
         userLatLng!.lat,
         userLatLng!.lng,
         undefined,
-        pageParam,
-        undefined,
+        pageParam.cursorId,
+        pageParam.cursorDist,
         undefined
       ),
     enabled: queryType === 'region',
     getNextPageParam: (lastPage) => {
-      return lastPage.nextCursor;
+       if (!lastPage?.nextCursor) return undefined;
+      return {
+        cursorId: lastPage.nextCursor,
+        cursorDist: lastPage.nextCursorDist,
+      };
     },
-    initialPageParam: undefined,
+    initialPageParam: {cursorId:undefined, cursorDist:undefined},
   });
 
 
@@ -71,7 +75,7 @@ const PreviewContentList: React.FC = () => {
   // });
 
 const placesIdListQuery = useInfiniteQuery({
-  queryKey: ['placesIdList'],
+  queryKey: ['placesIdList', selectedCategory],
   queryFn: ({ pageParam = undefined }) =>
     getPlaceByIdList(relatedPlaceIdList, pageParam),
   enabled: queryType === 'idList',
@@ -98,7 +102,7 @@ const placesIdListQuery = useInfiniteQuery({
 
   const placesDisplayQuery = useInfiniteQuery({
     queryKey: ['placesDisplay', selectedCategory],
-    queryFn: ({ pageParam = undefined }) =>
+    queryFn: ({ pageParam = {cursorId:undefined, cursorDist:undefined} }) =>
       getPlacesByDisplay(
         lastBounds!.getMin().y,
         lastBounds!.getMin().x,
@@ -107,15 +111,19 @@ const placesIdListQuery = useInfiniteQuery({
         userLatLng!.lat,
         userLatLng!.lng,
         selectedCategory ?? undefined,
-        pageParam,
-        undefined,
+        pageParam.cursorId,
+        pageParam.cursorDist,
         undefined
       ),
     enabled: queryType === 'category',
     getNextPageParam: (lastPage) => {
-      return lastPage.nextCursor;
+       if (!lastPage?.nextCursor) return undefined;
+      return {
+        cursorId: lastPage.nextCursor,
+        cursorDist: lastPage.nextCursorDist,
+      };
     },
-    initialPageParam: undefined,
+    initialPageParam: {cursorId:undefined, cursorDist:undefined},
   });
 
 

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -62,6 +62,7 @@ const PreviewContentList: React.FC = () => {
     enabled: queryType === 'category',
   });
 
+  // TODO: 무한스크롤
   // complete api: 지역 이름으로 프리뷰 리스트 호출 api
   useEffect(() => {
     if (placesRegionQuery.data) {

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -3,7 +3,7 @@ import PreviewContent from './PreviewContent';
 import { usePlaceStore } from '../../../store/placeStore';
 import { useMapStore } from '../../../store/mapStore';
 import { useShallow } from 'zustand/shallow';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSearchStore } from '../../../store/searchStore';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -11,17 +11,14 @@ import {
   getPlacesByDisplay,
   getPlacesByRegion,
 } from '../../../api/placeApi';
+import PreviewContentEmpty from './PreviewContentEmpty';
 
 const PreviewContentList: React.FC = () => {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const queryType = searchParams.get('queryType');
 
-  const { filteredPlaces, selectedCategory } = usePlaceStore(
-    useShallow((state) => ({
-      filteredPlaces: state.filteredPlaces,
-      selectedCategory: state.selectedCategory,
-    }))
-  );
+  const { filteredPlaces, selectedCategory, setPlaces } = usePlaceStore();
 
   const { userLatLng, lastBounds } = useMapStore(
     useShallow((state) => ({
@@ -38,7 +35,7 @@ const PreviewContentList: React.FC = () => {
   );
 
   const placesRegionQuery = useQuery({
-    queryKey: ['placesRegion'],
+    queryKey: ['placesRegion', selectedCategory],
     queryFn: () =>
       getPlacesByRegion(selectedRegion, userLatLng!.lat, userLatLng!.lng),
     enabled: queryType === 'region',
@@ -51,7 +48,7 @@ const PreviewContentList: React.FC = () => {
   });
 
   const placesDisplayQuery = useQuery({
-    queryKey: ['placesDisplay', lastBounds, userLatLng, selectedCategory],
+    queryKey: ['placesDisplay', selectedCategory],
     queryFn: () =>
       getPlacesByDisplay(
         lastBounds!.getMin().y,
@@ -68,24 +65,45 @@ const PreviewContentList: React.FC = () => {
   // complete api: 지역 이름으로 프리뷰 리스트 호출 api
   useEffect(() => {
     console.log('places[Region]Query:', placesRegionQuery.data);
-  }, [placesRegionQuery]);
+    if (placesRegionQuery.data) {
+      setPlaces(placesRegionQuery.data.places);
+    }
+  }, [placesRegionQuery.data, setPlaces]);
 
   // complete api: 검색창에서 enter시 연관검색어에서 추출한 장소 id 리스트로 프리뷰 리스트 호출 api
   useEffect(() => {
-    console.log('places[IdList]Query:', placesIdListQuery.data);
-  }, [placesIdListQuery]);
+    if (placesIdListQuery.data) {
+      console.log('places[IdList]Query:', placesIdListQuery.data.places);
+      setPlaces(placesIdListQuery.data.places);
+    }
+  }, [placesIdListQuery.data, setPlaces]);
 
   // complete api: 카테고리 선택시 현재 화면 기준으로 프리뷰 리스트 호출 api
   useEffect(() => {
-    console.log('places[Display]Query:', placesDisplayQuery.data);
-  }, [placesDisplayQuery]);
+    if (placesDisplayQuery.data) {
+      console.log('places[Display]Query:', placesDisplayQuery.data.places);
+      setPlaces(placesDisplayQuery.data.places);
+    }
+  }, [placesDisplayQuery.data, setPlaces]);
+
+  const isLoading =  (queryType === 'region' && placesRegionQuery.isLoading) ||
+  (queryType === 'idList' && placesIdListQuery.isLoading) ||
+  (queryType === 'category' && placesDisplayQuery.isLoading);
+
+  if(isLoading){
+    return <div></div>
+  }
 
   return (
     <div>
       <div>
         {filteredPlaces.map((place) => (
-          <PreviewContent key={place.title} place={place} />
-        ))}
+            <PreviewContent key={place.name} place={place} />
+          ))}
+
+          {filteredPlaces.length == 0 && 
+          <PreviewContentEmpty/>
+          }
       </div>
     </div>
   );

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -19,7 +19,7 @@ const PreviewContentList: React.FC = () => {
   const [searchParams] = useSearchParams();
   const queryType = searchParams.get('queryType');
 
-  const { filteredPlaces, selectedCategory, setPlaces } = usePlaceStore();
+  const { filteredPlaces, selectedCategory, setPlaces, refreshTrigger } = usePlaceStore();
 
   const { userLatLng, lastBounds } = useMapStore(
     useShallow((state) => ({
@@ -45,7 +45,7 @@ const PreviewContentList: React.FC = () => {
   // });
 
   const placesRegionQuery = useInfiniteQuery({
-    queryKey: ['placesRegion', selectedCategory],
+    queryKey: ['placesRegion', selectedCategory, refreshTrigger],
     queryFn: ({ pageParam = {cursorId:undefined, cursorDist:undefined} }) =>
       getPlacesByRegion(
         selectedRegion,
@@ -75,7 +75,7 @@ const PreviewContentList: React.FC = () => {
   // });
 
 const placesIdListQuery = useInfiniteQuery({
-  queryKey: ['placesIdList', selectedCategory],
+  queryKey: ['placesIdList', selectedCategory, refreshTrigger],
   queryFn: ({ pageParam = undefined }) =>
     getPlaceByIdList(relatedPlaceIdList, pageParam),
   enabled: queryType === 'idList',
@@ -101,7 +101,7 @@ const placesIdListQuery = useInfiniteQuery({
   // });
 
   const placesDisplayQuery = useInfiniteQuery({
-    queryKey: ['placesDisplay', selectedCategory],
+    queryKey: ['placesDisplay', selectedCategory, refreshTrigger],
     queryFn: ({ pageParam = {cursorId:undefined, cursorDist:undefined} }) =>
       getPlacesByDisplay(
         lastBounds!.getMin().y,

--- a/src/components/BottomSheet/Preview/PreviewContentList.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContentList.tsx
@@ -37,13 +37,6 @@ const PreviewContentList: React.FC = () => {
 
   // 무한 스크롤 적용
 
-  // const placesRegionQuery = useQuery({
-  //   queryKey: ['placesRegion', selectedCategory],
-  //   queryFn: () =>
-  //     getPlacesByRegion(selectedRegion, userLatLng!.lat, userLatLng!.lng),
-  //   enabled: queryType === 'region',
-  // });
-
   const placesRegionQuery = useInfiniteQuery({
     queryKey: ['placesRegion', selectedCategory, refreshTrigger],
     queryFn: ({ pageParam = {cursorId:undefined, cursorDist:undefined} }) =>
@@ -67,13 +60,6 @@ const PreviewContentList: React.FC = () => {
     initialPageParam: {cursorId:undefined, cursorDist:undefined},
   });
 
-
-  // const placesIdListQuery = useQuery({
-  //   queryKey: ['placesIdList'],
-  //   queryFn: () => getPlaceByIdList(relatedPlaceIdList),
-  //   enabled: queryType === 'idList',
-  // });
-
 const placesIdListQuery = useInfiniteQuery({
   queryKey: ['placesIdList', selectedCategory, refreshTrigger],
   queryFn: ({ pageParam = undefined }) =>
@@ -84,21 +70,6 @@ const placesIdListQuery = useInfiniteQuery({
   },
     initialPageParam: undefined,
 });
-
-  // const placesDisplayQuery = useQuery({
-  //   queryKey: ['placesDisplay', selectedCategory],
-  //   queryFn: () =>
-  //     getPlacesByDisplay(
-  //       lastBounds!.getMin().y,
-  //       lastBounds!.getMin().x,
-  //       lastBounds!.getMax().y,
-  //       lastBounds!.getMax().x,
-  //       userLatLng!.lat,
-  //       userLatLng!.lng,
-  //       selectedCategory ?? undefined
-  //     ),
-  //   enabled: queryType === 'category',
-  // });
 
   const placesDisplayQuery = useInfiniteQuery({
     queryKey: ['placesDisplay', selectedCategory, refreshTrigger],
@@ -143,7 +114,6 @@ const placesIdListQuery = useInfiniteQuery({
     isFetchingNextPage: activeQuery?.isFetchingNextPage ?? false,
   });
 
-  // TODO: 무한스크롤
   // complete api: 지역 이름으로 프리뷰 리스트 호출 api
   // useEffect(() => {
   //   if (placesRegionQuery.data) {

--- a/src/components/BottomSheet/Preview/PreviewPhotos.tsx
+++ b/src/components/BottomSheet/Preview/PreviewPhotos.tsx
@@ -12,7 +12,7 @@ const PreviewPhotos: React.FC<PreviewPhotosProps> = ({ images }) => {
           <img
             src={image}
             alt=''
-            className={`h-90 object-cover rounded-sm ${i === 0 ? 'rounded-tl-[20px]' : ''} ${i === 2 ? 'rounded-br-[20px]' : ''}`}
+            className={`h-90 w-full object-cover rounded-sm ${i === 0 ? 'rounded-tl-[20px]' : ''} ${i === 2 ? 'rounded-br-[20px]' : ''}`}
             key={i}
           />
         );

--- a/src/components/BottomSheet/SolmarkChip.tsx
+++ b/src/components/BottomSheet/SolmarkChip.tsx
@@ -3,13 +3,16 @@ import { useState } from 'react';
 
 import heart from '../../assets/heart.svg';
 import heartFill from '../../assets/heartFill.svg';
+import { usePlaceStore } from '../../store/placeStore';
 
 interface SolmarkChipProps {
   label?: boolean;
+  markCount?:number
 }
 
-const SolmarkChip: React.FC<SolmarkChipProps> = ({ label }) => {
-  const [isSolmark, setIsSolmark] = useState<boolean>(false);
+const SolmarkChip: React.FC<SolmarkChipProps> = ({ label, markCount }) => {
+  const {selectedPlace} = usePlaceStore();
+  const [isSolmark, setIsSolmark] = useState(selectedPlace?.isMarked);
 
   const handleClick = (e:React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation() // 쏠마크칩 클릭 시 navigate 방지
@@ -24,15 +27,15 @@ const SolmarkChip: React.FC<SolmarkChipProps> = ({ label }) => {
         <div
           className={`flex w-58 h-32 p-2 border rounded-lg justify-center items-center 
         ${isSolmark ? 'border-chip-mark' : 'border-chip-bg-mark'}`}>
-          <p
-            className={`w-30 text-center text-xs ${isSolmark ? 'text-chip-mark' : 'text-chip-bg-mark'}`}>
-            1
-          </p>
           <img
             src={isSolmark ? heartFill : heart}
             alt=''
             className='w-24 h-24'
           />
+          <p
+            className={`w-30 text-center text-xs ${isSolmark ? 'text-chip-mark' : 'text-chip-bg-mark'}`}>
+            {1}
+          </p>
         </div>
       ) : (
         <div

--- a/src/components/BottomSheet/Tag.tsx
+++ b/src/components/BottomSheet/Tag.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TagType } from '../../types';
 
 interface TagProps {
   name: string;
@@ -21,7 +22,7 @@ const Tag: React.FC<TagProps> = ({ name, header, number }) => {
       {number && (
         <div className={`${style} flex gap-4 bg-primary-100 py-6 text-primary-700`}>
           <p>{name}</p>
-          <span className='font-medium text-primary-900 font-semibold'>{number}</span>
+          <span className='text-primary-900 font-semibold'>{number}</span>
         </div>
       )}
 

--- a/src/components/BottomSheet/TagList.tsx
+++ b/src/components/BottomSheet/TagList.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import Tag from './Tag';
 import { TagType } from '../../types';
 
+//
 interface TagListProps {
   tags?: string[];
   detailTags?: TagType[];
   headerName?: string;
 }
-
 
 const TagList: React.FC<TagListProps> = ({
   tags,

--- a/src/components/BottomSheet/TagList.tsx
+++ b/src/components/BottomSheet/TagList.tsx
@@ -1,24 +1,37 @@
-import React from 'react'
+import React from 'react';
 import Tag from './Tag';
 import { TagType } from '../../types';
 
-interface TagListProps{
-    tags:TagType[];
-    headerName?: string;
-    counts?:number[];
+interface TagListProps {
+  tags?: string[];
+  detailTags?: TagType[];
+  headerName?: string;
 }
 
-const TagList:React.FC<TagListProps> = ({tags, headerName, counts}) => {
+
+const TagList: React.FC<TagListProps> = ({
+  tags,
+  detailTags,
+  headerName
+}) => {
+
   return (
     <div className='flex gap-8 px-16 pb-4 whitespace-nowrap overflow-x-scroll overflow-y-hidden touch-pan'>
-      {headerName && <Tag name={headerName} header/>}
-        {tags.map((tag, i) => {
-          return <Tag name={tag.text} number={counts && counts[i]} />;
+      {/* Tag Header */}
+      {headerName && <Tag name={headerName} header />}
+
+      {/* Preview tags */}
+      {tags?.map((tag, i) => {
+        return <Tag name={tag} key={i} />;
+      })}
+
+      {/* Detail tags with number */}
+      {detailTags &&
+        detailTags.map((tag, i) => {
+          return <Tag name={tag.tagName} number={tag.tagTotal} key={i} />;
         })}
-      </div>
+    </div>
+  );
+};
 
-
-  )
-}
-
-export default TagList
+export default TagList;

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -328,6 +328,7 @@ const MapSheet = () => {
   }, [newMarkerObjectList]);
 
   /* 현재 지도 화면을 기준으로 마커 재검색 함수 */
+  const {increaseRefreshTrigger} = usePlaceStore();
   const researchMarker = useCallback(async () => {
     if (!mapInstance.current) return;
 
@@ -341,25 +342,15 @@ const MapSheet = () => {
       selectedCategory ?? undefined
     );
 
-    // preview list 재검색
-    const preview = await getPlacesByDisplay(
-      lastBounds!.getMin().y,
-      lastBounds!.getMin().x,
-      lastBounds!.getMax().y,
-      lastBounds!.getMax().x,
-      userLatLng!.lat,
-      userLatLng!.lng,
-      selectedCategory ?? undefined
-    );
-    
+    // preview list 재검색을 위해 increase refresh 
+    increaseRefreshTrigger();
 
-    
     const result = createMarkerObjectList(data);
     
     const { objectList, idList } = result;
     setNewMarkerObjectList(objectList);
     setMarkerIdList(idList);
-    setPlaces(preview.places);
+    // setPlaces(preview.places);
 
     navigate('/map/list?queryType=category');
   }, [lastBounds, selectedCategory]);

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -21,7 +21,7 @@ import {
   createMarkersBounds,
 } from '../../utils/mapFunc';
 import { useSearchStore } from '../../store/searchStore';
-import { getPlaceDetail } from '../../api/placeApi';
+import { getPlaceDetail, getPlacesByDisplay } from '../../api/placeApi';
 import { usePlaceStore } from '../../store/placeStore';
 
 /* 지도 생성 */
@@ -183,7 +183,7 @@ const MapSheet = () => {
     }))
   );
 
-  const { selectedCategory } = usePlaceStore();
+  const { selectedCategory, setPlaces } = usePlaceStore();
 
   /* [useLayoutEffect] 지도 생성 및 초기 마커 추가 */
   useLayoutEffect(() => {
@@ -230,6 +230,19 @@ const MapSheet = () => {
         setMarkerIdList(idList);
       });
     }
+    
+    // // 초기 장소들
+    // getPlacesByDisplay(
+    //   newBounds!.getMin().y,
+    //   newBounds!.getMin().x,
+    //   newBounds!.getMax().y,
+    //   newBounds!.getMax().x,
+    //   userLatLng!.lat,
+    //   userLatLng!.lng
+    // ).then((res) => {
+    //   console.log(res);
+    //   setPlaces(res.places);
+    // });
 
     return () => {
       naver.maps.Event.removeListener(idleEventListener);
@@ -328,10 +341,25 @@ const MapSheet = () => {
       selectedCategory ?? undefined
     );
 
+    // preview list 재검색
+    const preview = await getPlacesByDisplay(
+      lastBounds!.getMin().y,
+      lastBounds!.getMin().x,
+      lastBounds!.getMax().y,
+      lastBounds!.getMax().x,
+      userLatLng!.lat,
+      userLatLng!.lng,
+      selectedCategory ?? undefined
+    );
+    
+
+    
     const result = createMarkerObjectList(data);
+    
     const { objectList, idList } = result;
     setNewMarkerObjectList(objectList);
     setMarkerIdList(idList);
+    setPlaces(preview.places);
 
     navigate('/map/list?queryType=category');
   }, [lastBounds, selectedCategory]);

--- a/src/components/Place/PreviewContentSummary.tsx
+++ b/src/components/Place/PreviewContentSummary.tsx
@@ -36,7 +36,7 @@ const PreviewContentSummary:React.FC<SummaryProps> = ({place}) => {
 
       <ReviewRange rating={place.rating} recommend={place.recommendationPercent}/>
 
-      <TagList tags={place.tags.map(tag=>({id:tag, text:tag}))}/>
+      <TagList tags={place.tags}/>
     </div>
   );
 };

--- a/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
+++ b/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
@@ -40,7 +40,7 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
 
   return (
     <div
-      className={`w-full h-54 flex justify-between items-center fixed z-10 px-9 ${isTop ? 'bg-transparent' : 'bg-white'} transition-colors duration-300`}>
+      className={`w-full h-54 flex justify-between items-center fixed z-70 px-9 ${isTop ? 'bg-transparent' : 'bg-white'} transition-colors duration-300`}>
       {/* 뒤로가기 */}
       <img
         src={isTop ? arrowTailWhite : arrowTail}

--- a/src/components/global/Modal.tsx
+++ b/src/components/global/Modal.tsx
@@ -11,7 +11,7 @@ interface ModalProps{
 
 const Modal:React.FC<ModalProps> = ({title, subtitle, leftText, rightText, onLeftClick, onRightClick}) => {
   return (
-    <div className='fixed inset-0 bg-black/80 flex justify-center items-center z-15'>
+    <div className='fixed inset-0 bg-black/80 flex justify-center items-center z-100'>
       <div className='bg-white rounded-lg p-20 pt-32 w-min-340 h-min-112 text-center'>
         <h3 className='text-primary-950 font-bold mb-8'>{title}</h3>
         <p className='text-primary-950 text-sm mb-24'>{subtitle}</p>

--- a/src/pages/RelatedSollect.tsx
+++ b/src/pages/RelatedSollect.tsx
@@ -1,19 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import TitleHeader from '../components/global/TitleHeader';
-import { useNavigate } from 'react-router-dom';
-import { fetchSollects } from '../api/sollectApi';
+import { useNavigate, useParams } from 'react-router-dom';
+import { fetchRelatedSollect, fetchSollects } from '../api/sollectApi';
 import { SollectPhotoType } from '../types';
 import SollectList from '../components/Sollect/SollectList';
 
 
 const RelatedSollect = () => {
   const navigate = useNavigate();
+  const {placeId} = useParams();
 
   const [sollects, setSollects] = useState<SollectPhotoType[]>([]);
 
+  // TODO: 무한스크롤
   useEffect(()=>{
     const getSollects = async ()=>{
-      const data = await fetchSollects();
+      const data = await fetchRelatedSollect(Number(placeId),1);
       setSollects(data);
     };
 

--- a/src/pages/Solmap.tsx
+++ b/src/pages/Solmap.tsx
@@ -6,7 +6,7 @@ import SearchPanel from '../components/Searching/SearchPanel';
 import { useSearchStore } from '../store/searchStore';
 import { usePlaceStore } from '../store/placeStore';
 import { useQuery } from '@tanstack/react-query';
-import { fetchPlaces } from '../api/placeApi';
+import { getPlacesByDisplay } from '../api/placeApi';
 import MapSheet from '../components/Map/MapSheet';
 import MapSearchBar from '../components/Searching/MapSearchBar';
 import { watchUserLocation } from '../utils/geolocation';
@@ -18,18 +18,12 @@ const Solmap: React.FC = () => {
 
   const { isFocused } = useSearchStore();
 
-  const setPlaces = usePlaceStore((state) => state.setPlaces);
-
   const { setUserLatLng } = useMapStore(
     useShallow((state) => ({
       setUserLatLng: state.setUserLatLng,
     }))
   );
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['places'],
-    queryFn: fetchPlaces,
-  });
 
   /* [useEffect] 위치 변경 감지 시작 */
   useEffect(() => {
@@ -52,18 +46,6 @@ const Solmap: React.FC = () => {
     };
   }, []);
 
-  useEffect(() => {
-    if (data) {
-      setPlaces(data);
-    }
-  }, [data]);
-
-  if (isLoading) {
-    return <p>로딩 중...</p>;
-  }
-  if (error) {
-    return <p>에러 발생</p>;
-  }
 
   return (
     <div className='h-full'>

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -49,7 +49,7 @@ const AppRouter = () => {
           <Route path='map/search' element={<SearchPage />} />
           <Route path='mark' element={<></>} />
           <Route path='profile' element={<Profile />} />
-          <Route path='related-sollect' element={<RelatedSollect />} />
+          <Route path='related-sollect/:placeId' element={<RelatedSollect />} />
           <Route path=':loginType/callback' element={<OAuthCallback />} />
         </Route>
         <Route path='login' element={<Login />} />

--- a/src/store/placeStore.ts
+++ b/src/store/placeStore.ts
@@ -1,17 +1,17 @@
 import { create } from 'zustand';
-import { Place } from '../types';
+import { DetailPlace, PreviewPlace } from '../types';
 
 interface PlaceStore {
-  places: Place[];
-  filteredPlaces: Place[];
-  recommendedPlaces: Place[];
-  selectedPlace: Place | null;
+  places: PreviewPlace[];
+  filteredPlaces: PreviewPlace[];
+  recommendedPlaces: PreviewPlace[];
+  selectedPlace: DetailPlace | null;
   selectedCategory: string | null;
-  setPlaces: (places: Place[]) => void;
-  setRecommendedPlaces: (recommendedPlaces: Place[]) => void;
+  setPlaces: (places: PreviewPlace[]) => void;
+  setRecommendedPlaces: (recommendedPlaces: PreviewPlace[]) => void;
   setCategory: (category: string | null) => void;
   clearCategory: () => void;
-  setPlace: (place: Place) => void;
+  setPlace: (place: DetailPlace) => void;
 }
 
 export const usePlaceStore = create<PlaceStore>((set, get) => ({
@@ -49,4 +49,5 @@ export const usePlaceStore = create<PlaceStore>((set, get) => ({
   setPlace: (place) => {
     set({ selectedPlace: place });
   },
+
 }));

--- a/src/store/placeStore.ts
+++ b/src/store/placeStore.ts
@@ -4,9 +4,11 @@ import { Place } from '../types';
 interface PlaceStore {
   places: Place[];
   filteredPlaces: Place[];
+  recommendedPlaces: Place[];
   selectedPlace: Place | null;
   selectedCategory: string | null;
   setPlaces: (places: Place[]) => void;
+  setRecommendedPlaces: (recommendedPlaces: Place[]) => void;
   setCategory: (category: string | null) => void;
   clearCategory: () => void;
   setPlace: (place: Place) => void;
@@ -15,6 +17,7 @@ interface PlaceStore {
 export const usePlaceStore = create<PlaceStore>((set, get) => ({
   places: [],
   filteredPlaces: [],
+  recommendedPlaces: [],
   selectedCategory: null,
   selectedPlace: null,
 
@@ -31,11 +34,12 @@ export const usePlaceStore = create<PlaceStore>((set, get) => ({
       set({
         selectedCategory: category,
         filteredPlaces: places.filter(
-          (place) => place.category.id === category
+          (place) => place.detailedCategory === category
         ),
       });
     }
   },
+  setRecommendedPlaces:(recommendedPlaces)=>set({recommendedPlaces:recommendedPlaces}),
   clearCategory: () => {
     set((state) => ({
       selectedCategory: null,

--- a/src/store/placeStore.ts
+++ b/src/store/placeStore.ts
@@ -7,11 +7,13 @@ interface PlaceStore {
   recommendedPlaces: PreviewPlace[];
   selectedPlace: DetailPlace | null;
   selectedCategory: string | null;
+  refreshTrigger: number;
   setPlaces: (places: PreviewPlace[]) => void;
   setRecommendedPlaces: (recommendedPlaces: PreviewPlace[]) => void;
   setCategory: (category: string | null) => void;
   clearCategory: () => void;
   setPlace: (place: DetailPlace) => void;
+  increaseRefreshTrigger: () => void;
 }
 
 export const usePlaceStore = create<PlaceStore>((set, get) => ({
@@ -20,6 +22,7 @@ export const usePlaceStore = create<PlaceStore>((set, get) => ({
   recommendedPlaces: [],
   selectedCategory: null,
   selectedPlace: null,
+  refreshTrigger:0,
 
   setPlaces: (places) => set({ places: places, filteredPlaces: places }),
   setCategory: (category) => {
@@ -49,5 +52,8 @@ export const usePlaceStore = create<PlaceStore>((set, get) => ({
   setPlace: (place) => {
     set({ selectedPlace: place });
   },
-
+  
+  increaseRefreshTrigger:()=>{
+    set((state) => ({ refreshTrigger: state.refreshTrigger + 1 }));
+  }
 }));

--- a/src/store/reviewWriteStore.ts
+++ b/src/store/reviewWriteStore.ts
@@ -9,11 +9,12 @@ interface ReviewWriteState {
   rating: number;
   setRating: (value: number) => void;
 
-  moodTags: TagType[];
-  setMoodTags: (tags: TagType[]) => void;
+  // TagType -> string으로 수정했습니다.
+  moodTags: string[];
+  setMoodTags: (tags: string[]) => void;
 
-  singleTags: TagType[];
-  setSingleTags: (tags: TagType[]) => void;
+  singleTags: string[];
+  setSingleTags: (tags: string[]) => void;
 
   text: string;
   setText: (value: string) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export type ReviewType = {
   emoji: Emoji;
   content: string;
   images: string[];
-  tags: TagType[];
+  tags: string[];
 };
 
 export type LatLngType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,27 +3,64 @@ export type Category = {
   id: string;
 };
 
-export type Place = {
+// export type Place = {
+//   id: number;
+//   name: string;
+//   closingTime:string;
+//   isOpen:boolean;
+//   category?:string;
+//   address?: string;
+//   isSoloRecommended:number;
+//   latitude: number;
+//   longitude: number;
+//   detailedCategory: string;
+//   rating: number;
+//   tags?: string[]; // TagType 제거
+//   thumbnailUrls: string[];
+//   openingHours?:Hours[];
+//   mood?:TagType[];
+//   solo?:TagType[];
+//   markedCount:number;
+// };
+
+type BasePlace = {
   id: number;
-  title: string;
-  address: string;
-  latitude: number;
-  longitude: number;
-  category: Category;
+  name: string;
+  closingTime: string;
+  isOpen: boolean;
+  detailedCategory: string;
+  isSoloRecommended: number;
   rating: number;
-  tags: TagType[];
-  hours: Hours[];
+  thumbnailUrls: string[];
 };
 
+export type DetailPlace = BasePlace & {
+  tags:{
+    mood: TagType[];
+    solo: TagType[];
+  }
+  markedCount: number;
+  openingHours:Hours[];
+  latitude: number;
+  longitude: number;
+  category:string;
+  address: string;
+};
+
+export type PreviewPlace = BasePlace & {
+  tags: string[];
+};
+
+
 type Hours = {
-  day: number;
+  dayOfWeek: number;
   startTime: string;
   endTime: string;
 };
 
 export type TagType = {
-  id: string;
-  text: string;
+  tagName: string;
+  tagTotal: number;
 };
 
 export type RelatedSearchWord = {
@@ -72,29 +109,28 @@ export type SollectPhotoType = {
   sollectId: number;
   title: string;
   thumbnailImage: string;
-  district:string;
-  neighborhood:string;
-  isMarked:boolean;
-  placeName:string;
+  district: string;
+  neighborhood: string;
+  isMarked: boolean;
+  placeName: string;
 };
 
 export type Paragraph = {
   seq: number;
   type: 'TEXT' | 'IMAGE';
   // content: 등록용   text: 조회용
-  content?: string;  // IMAGE일 경우 file name을 저장
-  text?:string;      // 쏠렉트 등록에서는 content인데, 쏠렉트 조회에서는 text라 optional로 필드 추가
+  content?: string; // IMAGE일 경우 file name을 저장
+  text?: string; // 쏠렉트 등록에서는 content인데, 쏠렉트 조회에서는 text라 optional로 필드 추가
   file?: File; // 이미지 파일을 저장할 수 있는 속성 추가
   imageUrl?: string; // 이미지 URL을 저장할 수 있는 속성 추가
 };
 
-
 export type placeSummary = {
-  PlaceId?:number;
-  name:string;
-  detailedCategory:string;
-  recommendationPercent:number;
-  tags:string[];
-  isMarked?:boolean;
-  rating:number;
-}
+  PlaceId?: number;
+  name: string;
+  detailedCategory: string;
+  recommendationPercent: number;
+  tags: string[];
+  isMarked?: boolean;
+  rating: number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ type BasePlace = {
   detailedCategory: string;
   isSoloRecommended: number;
   rating: number;
-  thumbnailUrls: string[];
+
 };
 
 export type DetailPlace = BasePlace & {
@@ -45,10 +45,12 @@ export type DetailPlace = BasePlace & {
   longitude: number;
   category:string;
   address: string;
+  thumbnailUrl: string[];
 };
 
 export type PreviewPlace = BasePlace & {
   tags: string[];
+  thumbnailUrls: string[];
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,9 @@ export type DetailPlace = BasePlace & {
   category:string;
   address: string;
   thumbnailUrl: string[];
+
+  // 디테일에서 쏠마크 되었는지 확인. 나중에 백엔드에서 받아옴
+  isMarked:boolean;
 };
 
 export type PreviewPlace = BasePlace & {


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#151 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
### 프리뷰 api 연동
프리뷰 무한 스크롤 구현

`placesRegionQuery`, `placesIdListQuery`, `placesDisplayQuery` 각각 무한 스크롤 쿼리 적용하고,
queryType에 따라 activeQuery를 결정해서 activeQuery의 places가 리스트에 보이도록 구현

### 디테일 api 연동
api response에 맞게 렌더링 수정


### Type 재정의
1. Place
Place는 프리뷰와 디테일 정보에서 공통으로 들어가는 필드를 BasePlace로 두고,
DetailPlace와 PreviewPlace로 구분해서 구현

2. Tag
Tag의 api response
- string 배열로 오는 경우
- mood, solo로 오는 경우 {tagName, tagTotal}

mood, solo로 오는 경우에만 TagType ({tagName:string, tagTotal:number}) 사용.
string [] 으로 오면 Type 따로 사용하지 않음

따라서 TagList는 tags와 detailTags 둘 중 하나를 받음
tags는 string[]
detailTags는 TagType[]
디테일 뷰 외에는 모두 tags로 전달하면 될 것 같다. (Review에서도 tags로)


### 추천 장소 recommendedPlaces로 관리
검색 결과가 없을 때 보여주는 추천 장소를 저장하기 위해
placeStore에 `recommendedPlaces` 추가


### 이 지역에서 검색
이 지역에서 검색 버튼을 눌렀을 때 리스트가 재설정 되어야하는데,
MapSheet에서도 무한스크롤 쿼리를 넣으면 코드가 중복되는 게 많을 것 같아서
placeStore에 `refreshTrigger` 변수를 추가.
`MapSheet`의 `researchMarker` 함수에서 `increaseRefreshTrigger()` 을 통해 refreshTrigger을 1 증가시킴.
`PreviewContentList`에서 각 무한 스크롤 쿼리들이 `refreshTrigger` 값이 바뀔때마다(증가할 때마다) 새롭게 데이터를 요청함.


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
Place Type
<img width="374" alt="image" src="https://github.com/user-attachments/assets/aecc74a6-c7d9-4438-ba55-8f2dcfe072f6" />



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
Tag 타입을 수정하면서 reviewWriteStore의 태그 타입도 수정해두었습니다.
TagType[] -> string[]
<img width="654" alt="image" src="https://github.com/user-attachments/assets/8433308b-6f9e-470a-91af-95e37784cbde" />


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

