### PR TITLE
Feat#170 쏠마크 쏠렉트, 마이 구현

### DIFF
--- a/src/api/sollectApi.ts
+++ b/src/api/sollectApi.ts
@@ -135,7 +135,7 @@ export const fetchSollectDetail = async (sollectId: number) => {
 export const deleteSollect = async (sollectId: number) => {
   // test 안해봄
   try {
-    const res = await privateAxios.get(ENDPOINT.SOLLECT.DELETE(sollectId));
+    const res = await privateAxios.delete(ENDPOINT.SOLLECT.DELETE(sollectId));
     console.log(res);
     return res.data.data;
   } catch (e) {

--- a/src/api/solmarkApi.ts
+++ b/src/api/solmarkApi.ts
@@ -54,3 +54,18 @@ export const fetchSolmarkSollect = async (cursorId?: number) => {
     console.log(e);
   }
 };
+
+export const fetchMySolmarkSollect = async (cursorId?: number) => {
+    try {
+    const res = await privateAxios.get(ENDPOINT.SOLMARK_MY_SOLLECT, {
+      params: {
+        cursorId: cursorId,
+        size: undefined,
+      },
+    });
+    console.log(res.data.data.contents);
+    return res.data.data.contents;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/src/api/solmarkApi.ts
+++ b/src/api/solmarkApi.ts
@@ -13,7 +13,9 @@ export const fetchPlaceCollections = async () => {
 
 export const fetchPlacesByCollectionId = async (collectionId: number) => {
   try {
-    const res = await privateAxios.get(ENDPOINT.SOLMARK_PLACE_COLLECTION_PLACES(collectionId));
+    const res = await privateAxios.get(
+      ENDPOINT.SOLMARK_PLACE_COLLECTION_PLACES(collectionId)
+    );
     console.log(res.data.data.places);
     return res.data.data.places;
   } catch (e) {
@@ -21,14 +23,33 @@ export const fetchPlacesByCollectionId = async (collectionId: number) => {
   }
 };
 
-export const patchSolmark = async (placeId:number, addCollectionIds:number[], removeCollectionIds:number[])  => {
-    try {
+export const patchSolmark = async (
+  placeId: number,
+  addCollectionIds: number[],
+  removeCollectionIds: number[]
+) => {
+  try {
     const res = await privateAxios.patch(ENDPOINT.SOLMARK_PLACE(placeId), {
       addCollectionIds,
       removeCollectionIds,
     });
     console.log(res);
     return res.data;
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+export const fetchSolmarkSollect = async (cursorId?: number) => {
+  try {
+    const res = await privateAxios.get(ENDPOINT.SOLMARK_SOLLECT, {
+      params: {
+        cursorId: cursorId,
+        size: undefined,
+      },
+    });
+    console.log(res.data.data.contents);
+    return res.data.data.contents;
   } catch (e) {
     console.log(e);
   }

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -41,6 +41,7 @@ export const ENDPOINT = {
 
   // solmark
   SOLMARK_SOLLECT: '/api/solmark/sollect',
+  SOLMARK_MY_SOLLECT: '/api/solmark/sollect/my',
   
   SOLMARK_PLACE_COLLECTION: '/api/solmark/place/collections',                     // 리스트 조회
   SOLMARK_PLACE_COLLECTION_PLACES: (collectionId: number) =>

--- a/src/auth/OAuthCallback.tsx
+++ b/src/auth/OAuthCallback.tsx
@@ -42,8 +42,10 @@ const OAuthCallback = () => {
       })
       .then((response) => {
         const accessToken = response.data.data.accessToken;
+        const userId = response.data.data.userId;
         // Store tokens in local storage or state management
         localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('userId', userId);
 
         login();
 

--- a/src/components/BottomSheet/SolmarkChip.tsx
+++ b/src/components/BottomSheet/SolmarkChip.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useState } from 'react';
 
 import heart from '../../assets/heart.svg';
-import heartFill from '../../assets/heartFill.svg';
+import heartFillWhite from '../../assets/heartFillWhite.svg';
 import { usePlaceStore } from '../../store/placeStore';
 import { patchSolmark } from '../../api/solmarkApi';
 
 interface SolmarkChipProps {
   label?: boolean;
   markCount?: number;
+  isMarked?:boolean;
   placeId: number;
 }
 
@@ -16,11 +17,20 @@ const SolmarkChip: React.FC<SolmarkChipProps> = ({
   placeId,
   label,
   markCount,
+  isMarked
 }) => {
   const { selectedPlace } = usePlaceStore();
   const [isSolmark, setIsSolmark] = useState(
     label ? selectedPlace?.isMarked : false
   );
+  const [count, setCount] = useState(markCount ? markCount : 0);
+
+  useEffect(()=>{
+    if(isMarked){
+      setIsSolmark(true);
+    }
+  },[]) 
+
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation(); // 쏠마크칩 클릭 시 navigate 방지
@@ -32,8 +42,10 @@ const SolmarkChip: React.FC<SolmarkChipProps> = ({
 
     if (isSolmark) {
       patchSolmark(placeId, empty, array);
+      setCount(count-1);
     } else {
       patchSolmark(placeId, array, empty);
+      setCount(count+1);
     }
   };
 
@@ -42,23 +54,23 @@ const SolmarkChip: React.FC<SolmarkChipProps> = ({
       {label ? (
         <div
           className={`flex w-58 h-32 p-2 border rounded-lg justify-center items-center 
-        ${isSolmark ? 'border-chip-mark' : 'border-chip-bg-mark'}`}>
+        ${isSolmark ? 'border-chip-mark bg-chip-mark' : 'border-chip-bg-mark'}`}>
           <img
-            src={isSolmark ? heartFill : heart}
+            src={isSolmark ? heartFillWhite : heart}
             alt=''
             className='w-24 h-24'
           />
           <p
-            className={`w-30 text-center text-xs ${isSolmark ? 'text-chip-mark' : 'text-chip-bg-mark'}`}>
-            {markCount}
+            className={`w-30 text-center text-xs ${isSolmark ? 'text-white' : 'text-chip-bg-mark'}`}>
+            {count}
           </p>
         </div>
       ) : (
         <div
           className={`flex w-24 h-24 border rounded-lg justify-center items-center 
-        ${isSolmark ? 'border-chip-mark' : 'border-chip-bg-mark'}`}>
+        ${isSolmark ? 'bg-chip-mark border-chip-mark' : 'border-chip-bg-mark'}`}>
           <img
-            src={isSolmark ? heartFill : heart}
+            src={isSolmark ? heartFillWhite : heart}
             alt=''
             className='w-24 h-24'
           />

--- a/src/components/BottomSheet/SolmarkChip.tsx
+++ b/src/components/BottomSheet/SolmarkChip.tsx
@@ -35,10 +35,8 @@ const SolmarkChip: React.FC<SolmarkChipProps> = ({
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation(); // 쏠마크칩 클릭 시 navigate 방지
     setIsSolmark((prev) => !prev);
-    // TODO: solmark place api 추가
     const array: number[] = [1];
     const empty: number[] = [];
-    console.log(isSolmark);
 
     if (isSolmark) {
       patchSolmark(placeId, empty, array);

--- a/src/components/Place/PreviewContentSummary.tsx
+++ b/src/components/Place/PreviewContentSummary.tsx
@@ -6,10 +6,11 @@ import { placeSummary } from '../../types';
 
 interface SummaryProps {
   place: placeSummary;
+  isMarked?:boolean;
 }
 
 // { place }: placeSummary
-const PreviewContentSummary: React.FC<SummaryProps> = ({ place }) => {
+const PreviewContentSummary: React.FC<SummaryProps> = ({ place, isMarked }) => {
   if (!place) {
     return;
   }
@@ -29,7 +30,7 @@ const PreviewContentSummary: React.FC<SummaryProps> = ({ place }) => {
 
         {/* right */}
         {/* preview */}
-        <SolmarkChip placeId={place.PlaceId} />
+        <SolmarkChip placeId={place.PlaceId} isMarked={isMarked}/>
       </div>
 
       <ReviewRange

--- a/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
+++ b/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import Modal from '../../global/Modal';
 import { deleteSollect } from '../../../api/sollectApi';
 import EditDeletePopover from '../../global/EditDeletePopover';
+import { useSollectDetailStore } from '../../../store/sollectDetailStore';
 
 const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   const navigate = useNavigate();
@@ -16,11 +17,10 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { sollectId } = useParams();
 
-  // TODO: 내 글인지 확인
-  // const userId = localStorage.getItem('userId');
-  // const {authorId} = useSollectDetailStore(); // 쏠렉트 상세 조회에서 받아오기
-  // const mySollect = userId === authorId;
-  const mySollect = true;
+  // 내 글인지 확인
+  const userId = localStorage.getItem('userId');
+  const {writerId} = useSollectDetailStore(); // 쏠렉트 상세 조회에서 받아오기
+  const mySollect = Number(userId) === writerId;
 
   const clickDeleteModal = () => {
     setShowDeleteModal(true);

--- a/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
+++ b/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
@@ -3,12 +3,12 @@ import arrowTail from '../../../assets/arrowTail.svg';
 import arrowTailWhite from '../../../assets/arrowTailWhite.svg';
 import kebabWhite from '../../../assets/kebabWhite.svg';
 import kebabGray from '../../../assets/kebabGray.svg';
-import edit from '../../../assets/edit.svg';
-import deleteIcon from '../../../assets/delete.svg';
+
 
 import { useNavigate, useParams } from 'react-router-dom';
 import Modal from '../../global/Modal';
 import { deleteSollect } from '../../../api/sollectApi';
+import EditDeletePopover from '../../global/EditDeletePopover';
 
 const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   const navigate = useNavigate();
@@ -25,13 +25,13 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   const clickDeleteModal = () => {
     setShowDeleteModal(true);
   };
+
   const onLeftClick = () => {
     setShowDeleteModal(false);
   };
+
   const onRightClick = () => {
     setShowDeleteModal(false);
-    // delete
-    // sollect id 응답으로 받아야함
     deleteSollect(Number(sollectId));
     navigate(-1);
   };
@@ -57,34 +57,17 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
             onClick={() => setShowMenu(!showMenu)}
           />
 
-          {showMenu && (
-            <div
-              className='absolute top-40 right-12 rounded-lg border-1 border-primary-100 bg-white w-136 shadow-[3px_3px_4px_0px_rgba(24,24,24,0.06)] text-primary-950
-text-sm'>
-              {/* 수정 */}
-              <div className='p-12 flex gap-8 items-center border-b border-primary-100'>
-                <img src={edit} alt='edit' />
-                수정
-              </div>
-              {/* 삭제 */}
-              <div
-                className='p-12 flex gap-8 items-center'
-                onClick={clickDeleteModal}>
-                <img src={deleteIcon} alt='delete' />
-                삭제
-              </div>
+          {showMenu && <EditDeletePopover clickDeleteModal={clickDeleteModal}/>}
 
-              {showDeleteModal && (
-                <Modal
-                  title='정말 삭제하시겠습니까?'
-                  subtitle='삭제하면 복구할 수 없어요!'
-                  leftText='취소'
-                  rightText='삭제'
-                  onLeftClick={onLeftClick}
-                  onRightClick={onRightClick}
-                />
-              )}
-            </div>
+          {showDeleteModal && (
+            <Modal
+              title='정말 삭제하시겠습니까?'
+              subtitle='삭제하면 복구할 수 없어요!'
+              leftText='취소'
+              rightText='삭제'
+              onLeftClick={onLeftClick}
+              onRightClick={onRightClick}
+            />
           )}
         </div>
       )}

--- a/src/components/Sollect/SollectList.tsx
+++ b/src/components/Sollect/SollectList.tsx
@@ -6,6 +6,7 @@ const SollectList: React.FC<SollectListProps> = ({
   horizontal,
   sollects,
   customStyle,
+  isMine
 }) => {
   let style = customStyle;
 
@@ -19,7 +20,7 @@ const SollectList: React.FC<SollectListProps> = ({
     <div className='flex justify-center'>
       <div className={style}>
         {sollects.map((sollect) => {
-          return <SollectPhoto sollect={sollect} key={sollect.sollectId} />;
+          return <SollectPhoto sollect={sollect} key={sollect.sollectId} isMine={isMine}/>;
         })}
       </div>
     </div>

--- a/src/components/Sollect/SollectPhoto.tsx
+++ b/src/components/Sollect/SollectPhoto.tsx
@@ -3,7 +3,11 @@ import { SollectPhotoProps } from '../../interface';
 import { useNavigate } from 'react-router-dom';
 import SollectMark from './SollectMark';
 
-const SollectPhoto: React.FC<SollectPhotoProps> = ({ sollect }) => {
+type Props = SollectPhotoProps &{
+  isMine?:boolean;
+}
+
+const SollectPhoto: React.FC<Props> = ({ sollect, isMine }) => {
   const navigate = useNavigate();
   const [marked, setMarked] = useState(sollect.isMarked);
 
@@ -28,11 +32,15 @@ const SollectPhoto: React.FC<SollectPhotoProps> = ({ sollect }) => {
       <div
         className='absolute top-8 right-8'
         onClick={(e) => e.stopPropagation()}>
-        <SollectMark
-          marked={marked}
-          setMarked={setMarked}
-          id={sollect.sollectId}
-        />
+        {isMine ? (
+          <></>
+        ) : (
+          <SollectMark
+            marked={marked}
+            setMarked={setMarked}
+            id={sollect.sollectId}
+          />
+        )}
       </div>
 
       <div className='p-20 z-1 text-white'>

--- a/src/components/Sollect/SollectPhoto.tsx
+++ b/src/components/Sollect/SollectPhoto.tsx
@@ -2,6 +2,10 @@ import React, { useState } from 'react';
 import { SollectPhotoProps } from '../../interface';
 import { useNavigate } from 'react-router-dom';
 import SollectMark from './SollectMark';
+import kebabWhite from '../../assets/kebabWhite.svg';
+import EditDeletePopover from '../global/EditDeletePopover';
+import { deleteSollect } from '../../api/sollectApi';
+import Modal from '../global/Modal';
 
 type Props = SollectPhotoProps &{
   isMine?:boolean;
@@ -10,10 +14,29 @@ type Props = SollectPhotoProps &{
 const SollectPhoto: React.FC<Props> = ({ sollect, isMine }) => {
   const navigate = useNavigate();
   const [marked, setMarked] = useState(sollect.isMarked);
+  const [showMenu, setShowMenu] = useState(false);
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const handleClick = () => {
     navigate(`/sollect/${sollect.sollectId}`);
   };
+
+  // 쏠마크 마이페이지에서 사용
+    const clickDeleteModal = () => {
+    setShowDeleteModal(true);
+  };
+
+    const onLeftClick = () => {
+      setShowDeleteModal(false);
+    };
+  
+    const onRightClick = async () => {
+      setShowDeleteModal(false);
+      await deleteSollect(Number(sollect.sollectId));
+      setShowMenu(false);
+      location.reload();
+    };
+  
 
   return (
     <div
@@ -33,7 +56,17 @@ const SollectPhoto: React.FC<Props> = ({ sollect, isMine }) => {
         className='absolute top-8 right-8'
         onClick={(e) => e.stopPropagation()}>
         {isMine ? (
-          <></>
+          <div className='relative'>
+            <img
+              src={kebabWhite}
+              alt='kebab'
+              className='w-24 h-24'
+              onClick={() => setShowMenu(!showMenu)}
+            />
+            {showMenu && (
+              <EditDeletePopover clickDeleteModal={clickDeleteModal} />
+            )}
+          </div>
         ) : (
           <SollectMark
             marked={marked}
@@ -41,6 +74,17 @@ const SollectPhoto: React.FC<Props> = ({ sollect, isMine }) => {
             id={sollect.sollectId}
           />
         )}
+
+        {showDeleteModal && (
+            <Modal
+              title='정말 삭제하시겠습니까?'
+              subtitle='삭제하면 복구할 수 없어요!'
+              leftText='취소'
+              rightText='삭제'
+              onLeftClick={onLeftClick}
+              onRightClick={onRightClick}
+            />
+          )}
       </div>
 
       <div className='p-20 z-1 text-white'>

--- a/src/components/Solmark/SolmarkContentMy.tsx
+++ b/src/components/Solmark/SolmarkContentMy.tsx
@@ -14,16 +14,13 @@ const SolmarkContentMy = () => {
 
   useEffect(() => {
     if (data) {
-      data.map((sollect: SollectPhotoType) => {
-        sollect.isMarked = false;
-      });
       setSollects(data);
     }
   }, [data]);
 
   return (
     <div className='py-16'>
-        <SollectList sollects={sollects} />
+        <SollectList sollects={sollects} isMine/>
     </div>
   );
 };

--- a/src/components/Solmark/SolmarkContentMy.tsx
+++ b/src/components/Solmark/SolmarkContentMy.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import { SollectPhotoType } from '../../types';
+import { fetchMySolmarkSollect } from '../../api/solmarkApi';
+import SollectList from '../Sollect/SollectList';
+
+const SolmarkContentMy = () => {
+  const { data } = useQuery({
+    queryKey: ['solmarkSollects'],
+    queryFn: () => fetchMySolmarkSollect(),
+  });
+
+  const [sollects, setSollects] = useState<SollectPhotoType[]>([]);
+
+  useEffect(() => {
+    if (data) {
+      data.map((sollect: SollectPhotoType) => {
+        sollect.isMarked = false;
+      });
+      setSollects(data);
+    }
+  }, [data]);
+
+  return (
+    <div className='py-16'>
+        <SollectList sollects={sollects} />
+    </div>
+  );
+};
+
+export default SolmarkContentMy;

--- a/src/components/Solmark/SolmarkContentMy.tsx
+++ b/src/components/Solmark/SolmarkContentMy.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { SollectPhotoType } from '../../types';
 import { fetchMySolmarkSollect } from '../../api/solmarkApi';
 import SollectList from '../Sollect/SollectList';
+import SolmarkNoResult from './SolmarkNoResult';
 
 const SolmarkContentMy = () => {
   const { data } = useQuery({
@@ -20,7 +21,11 @@ const SolmarkContentMy = () => {
 
   return (
     <div className='py-16'>
-        <SollectList sollects={sollects} isMine/>
+      {sollects.length != 0 ? (
+        <SollectList sollects={sollects} isMine />
+      ) : (
+        <SolmarkNoResult type='my' />
+      )}
     </div>
   );
 };

--- a/src/components/Solmark/SolmarkContentSollect.tsx
+++ b/src/components/Solmark/SolmarkContentSollect.tsx
@@ -4,8 +4,10 @@ import { fetchSolmarkSollect } from '../../api/solmarkApi';
 import SollectList from '../Sollect/SollectList';
 import { SollectPhotoType } from '../../types';
 import arrow from '../../assets/arrow.svg';
+import { useNavigate } from 'react-router-dom';
 
 const SolmarkContentSollect = () => {
+  const navigate = useNavigate();
   const { data } = useQuery({
     queryKey: ['solmarkSollects'],
     queryFn: () => fetchSolmarkSollect(),
@@ -29,7 +31,9 @@ const SolmarkContentSollect = () => {
             <p className='font-bold text-primary-950'>
               아직 저장된 쏠렉트가 없어요!
             </p>
-            <p className='flex text-center justify-center'>
+            <p
+              className='flex text-center justify-center'
+              onClick={() => navigate('/sollect')}>
               쏠렉트 보러 가기
               <img src={arrow} alt='' className='w-24 h-24' />{' '}
             </p>

--- a/src/components/Solmark/SolmarkContentSollect.tsx
+++ b/src/components/Solmark/SolmarkContentSollect.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { fetchSolmarkSollect } from '../../api/solmarkApi';
 import SollectList from '../Sollect/SollectList';
 import { SollectPhotoType } from '../../types';
+import arrow from '../../assets/arrow.svg';
 
 const SolmarkContentSollect = () => {
   const { data } = useQuery({
@@ -20,7 +21,21 @@ const SolmarkContentSollect = () => {
 
   return (
     <div className='py-16'>
-      {sollects.length !== 0 ? <SollectList sollects={data} /> : <div>no</div>}
+      {sollects.length !== 1 ? (
+        <SollectList sollects={data} />
+      ) : (
+        <div className='flex justify-center items-center h-full text-center'>
+          <div className='pt-240'>
+            <p className='font-bold text-primary-950'>
+              아직 저장된 쏠렉트가 없어요!
+            </p>
+            <p className='flex text-center justify-center'>
+              쏠렉트 보러 가기
+              <img src={arrow} alt='' className='w-24 h-24' />{' '}
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Solmark/SolmarkContentSollect.tsx
+++ b/src/components/Solmark/SolmarkContentSollect.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import { fetchSolmarkSollect } from '../../api/solmarkApi';
+import SollectList from '../Sollect/SollectList';
+import { SollectPhotoType } from '../../types';
+
+const SolmarkContentSollect = () => {
+  const { data } = useQuery({
+    queryKey: ['solmarkSollects'],
+    queryFn: () => fetchSolmarkSollect(),
+  });
+
+  const [sollects, setSollects] = useState<SollectPhotoType[]>([]);
+
+  useEffect(() => {
+    if (data) {
+      setSollects(data);
+    }
+  }, [data]);
+
+  return (
+    <div className='py-16'>
+      {sollects.length !== 0 ? <SollectList sollects={data} /> : <div>no</div>}
+    </div>
+  );
+};
+
+export default SolmarkContentSollect;

--- a/src/components/Solmark/SolmarkContentSollect.tsx
+++ b/src/components/Solmark/SolmarkContentSollect.tsx
@@ -23,21 +23,24 @@ const SolmarkContentSollect = () => {
 
   return (
     <div className='py-16'>
-      {sollects.length !== 1 ? (
-        <SollectList sollects={data} />
+      {sollects.length !== 0 ? (
+        <SollectList
+          sollects={sollects.map((sollect) => {
+            sollect.isMarked = true;
+            return sollect;
+          })}
+        />
       ) : (
-        <div className='flex justify-center items-center h-full text-center'>
-          <div className='pt-240'>
-            <p className='font-bold text-primary-950'>
-              아직 저장된 쏠렉트가 없어요!
-            </p>
-            <p
-              className='flex text-center justify-center'
-              onClick={() => navigate('/sollect')}>
-              쏠렉트 보러 가기
-              <img src={arrow} alt='' className='w-24 h-24' />{' '}
-            </p>
-          </div>
+        <div className='text-center py-250'>
+          <p className='font-bold text-primary-950 mb-5'>
+            아직 저장된 쏠렉트가 없어요!
+          </p>
+          <p
+            className='flex justify-center text-sm text-primary-700 underline items-center'
+            onClick={() => navigate('/sollect')}>
+            쏠렉트 보러 가기
+            <img src={arrow} alt='' className='w-24 h-24' />{' '}
+          </p>
         </div>
       )}
     </div>

--- a/src/components/Solmark/SolmarkContentSollect.tsx
+++ b/src/components/Solmark/SolmarkContentSollect.tsx
@@ -3,11 +3,10 @@ import React, { useEffect, useState } from 'react';
 import { fetchSolmarkSollect } from '../../api/solmarkApi';
 import SollectList from '../Sollect/SollectList';
 import { SollectPhotoType } from '../../types';
-import arrow from '../../assets/arrow.svg';
 import { useNavigate } from 'react-router-dom';
+import SolmarkNoResult from './SolmarkNoResult';
 
 const SolmarkContentSollect = () => {
-  const navigate = useNavigate();
   const { data } = useQuery({
     queryKey: ['solmarkSollects'],
     queryFn: () => fetchSolmarkSollect(),
@@ -31,17 +30,7 @@ const SolmarkContentSollect = () => {
           })}
         />
       ) : (
-        <div className='text-center py-250'>
-          <p className='font-bold text-primary-950 mb-5'>
-            아직 저장된 쏠렉트가 없어요!
-          </p>
-          <p
-            className='flex justify-center text-sm text-primary-700 underline items-center'
-            onClick={() => navigate('/sollect')}>
-            쏠렉트 보러 가기
-            <img src={arrow} alt='' className='w-24 h-24' />{' '}
-          </p>
-        </div>
+        <SolmarkNoResult type='sollect' />
       )}
     </div>
   );

--- a/src/components/Solmark/SolmarkNoResult.tsx
+++ b/src/components/Solmark/SolmarkNoResult.tsx
@@ -10,7 +10,7 @@ const SolmarkNoResult = ({ type }: { type: string }) => {
     if (type == 'sollect') {
       url = '/sollect';
     } else if (type == 'my') {
-      url = '/solllect/write';
+      url = '/sollect/write';
     }
 
     navigate(url);

--- a/src/components/Solmark/SolmarkNoResult.tsx
+++ b/src/components/Solmark/SolmarkNoResult.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import arrow from '../../assets/arrow.svg';
+import { useNavigate } from 'react-router-dom';
+
+const SolmarkNoResult = ({ type }: { type: string }) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    let url = '';
+    if (type == 'sollect') {
+      url = '/sollect';
+    } else if (type == 'my') {
+      url = '/solllect/write';
+    }
+
+    navigate(url);
+  };
+  return (
+    <div className='text-center py-250'>
+      <p className='font-bold text-primary-950 mb-5'>
+        아직 {type === 'sollect' ? '저장된' : '작성된'} 쏠렉트가 없어요!
+      </p>
+      <p
+        className='flex justify-center text-sm text-primary-700 underline items-center'
+        onClick={handleClick}>
+        {type === 'sollect' ? '쏠렉트 보러가기' : '쏠렉트 작성하러 가기'}
+        <img src={arrow} alt='' className='w-24 h-24' />{' '}
+      </p>
+    </div>
+  );
+};
+
+export default SolmarkNoResult;

--- a/src/components/Solmark/SolmarkTab.tsx
+++ b/src/components/Solmark/SolmarkTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const SolmarkTab = () => {
@@ -13,6 +13,17 @@ const SolmarkTab = () => {
     setActive(i);
     navigate(`/mark/${tabs[i]}`);
   };
+
+  useEffect(()=>{
+    const path = location.pathname
+    if(path.includes("place")){
+      setActive(0);
+    }else if(path.includes("sollect")){
+      setActive(1);
+    }else if(path.includes("my")){
+      setActive(2);
+    }
+  },[])
 
   return (
     <div className='border-b border-primary-100 w-full mt-24 px-16'>

--- a/src/components/global/EditDeletePopover.tsx
+++ b/src/components/global/EditDeletePopover.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import edit from '../../assets/edit.svg';
+import deleteIcon from '../../assets/delete.svg';
+
+type EditDeletePopoverProps = {
+  clickDeleteModal: () => void;
+};
+const EditDeletePopover: React.FC<EditDeletePopoverProps> = ({
+  clickDeleteModal,
+}) => {
+  const my = location.pathname.includes('/mark/my');
+  return (
+    <div
+      className={`absolute top-${my ? '30' : '40'} right-4 rounded-lg border-1 border-primary-100 bg-white w-136 shadow-[3px_3px_4px_0px_rgba(24,24,24,0.06)] text-primary-950
+text-sm`}>
+      {/* 수정 */}
+      <div className='p-12 flex gap-8 items-center border-b border-primary-100'>
+        <img src={edit} alt='edit' />
+        수정
+      </div>
+      {/* 삭제 */}
+      <div className='p-12 flex gap-8 items-center' onClick={clickDeleteModal}>
+        <img src={deleteIcon} alt='delete' />
+        삭제
+      </div>
+    </div>
+  );
+};
+
+export default EditDeletePopover;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -26,6 +26,7 @@ export interface SollectListProps {
   sollects: SollectPhotoType[];
   horizontal?: boolean;
   customStyle?: string;
+  isMine?:boolean;
 }
 
 export interface SollectGroupProps {

--- a/src/pages/SolmarkPlacePreviewPage.tsx
+++ b/src/pages/SolmarkPlacePreviewPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchPlacesByCollectionId } from '../api/solmarkApi';
 import { useSolmarkStore } from '../store/solmarkStore';
+import PreviewContentSummary from '../components/Place/PreviewContentSummary';
 
 const SolmarkPlacePreviewPage = () => {
   const navigate = useNavigate();
@@ -24,7 +25,7 @@ const SolmarkPlacePreviewPage = () => {
     if (data) {
       setPlaces(data);
     }
-  }, []);
+  }, [data]);
 
   return (
     <div>
@@ -37,6 +38,13 @@ const SolmarkPlacePreviewPage = () => {
         <p className='text-primary-950 text-sm py-24 px-16 pb-8'>
           장소 {places.length}개
         </p>
+        <div>
+          {places.map((place)=>{
+            return(
+              <PreviewContentSummary place={place} isMarked={true} key={place.PlaceId}/>
+            )
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -23,6 +23,7 @@ import SolrouteWritePage from '../pages/SolrouteWritePage';
 import SolmarkPage from '../pages/SolmarkPage';
 import SolmarkContentPlace from '../components/Solmark/SolmarkContentPlace';
 import SolmarkPlacePreviewPage from '../pages/SolmarkPlacePreviewPage';
+import SolmarkContentSollect from '../components/Solmark/SolmarkContentSollect';
 
 const AppRouter = () => {
   const location = useLocation();
@@ -55,7 +56,7 @@ const AppRouter = () => {
           <Route path='mark' element={<SolmarkPage/>} >
             <Route index element={<SolmarkContentPlace/>}/>
             <Route path='place' element={<SolmarkContentPlace/>}/>
-            <Route path='sollect' element={<SolmarkContentPlace/>}/>
+            <Route path='sollect' element={<SolmarkContentSollect/>}/>
           </Route>
           <Route path='mark/place/list/:collectionId' element={<SolmarkPlacePreviewPage />}/>
 

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -24,6 +24,7 @@ import SolmarkPage from '../pages/SolmarkPage';
 import SolmarkContentPlace from '../components/Solmark/SolmarkContentPlace';
 import SolmarkPlacePreviewPage from '../pages/SolmarkPlacePreviewPage';
 import SolmarkContentSollect from '../components/Solmark/SolmarkContentSollect';
+import SolmarkContentMy from '../components/Solmark/SolmarkContentMy';
 
 const AppRouter = () => {
   const location = useLocation();
@@ -57,6 +58,7 @@ const AppRouter = () => {
             <Route index element={<SolmarkContentPlace/>}/>
             <Route path='place' element={<SolmarkContentPlace/>}/>
             <Route path='sollect' element={<SolmarkContentSollect/>}/>
+            <Route path='my' element={<SolmarkContentMy/>}/>
           </Route>
           <Route path='mark/place/list/:collectionId' element={<SolmarkPlacePreviewPage />}/>
 

--- a/src/store/sollectDetailStore.ts
+++ b/src/store/sollectDetailStore.ts
@@ -14,6 +14,7 @@ interface SollectDetailStore {
   contents:Paragraph[];
   markedCount:number;
   placeSummaries:placeSummary[];
+  writerId:number;
 
   setSollectDetail:(data:SollectDetailStore)=>void;
 }
@@ -31,6 +32,7 @@ export const useSollectDetailStore = create<SollectDetailStore>((set) => ({
   contents:[],
   markedCount:0,
   placeSummaries:[],
+  writerId:0,
 
   setSollectDetail:(data)=>set(()=>({...data})),
 


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#170 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
쏠마크 쏠렉트, 마이 페이지를 구현했습니다.

저장한 쏠렉트 조회 페이지 구현
내가 작성한 쏠렉트 조회 페이지 구현
수정 삭제 버튼 컴포넌트화 EditDeletePopover.tsx
로그인할 때 Local Storage에 userId를 저장하고 쏠렉트 작성자 id와 비교해서 동일할 때만 수정, 삭제 버튼 표시



<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="398" alt="image" src="https://github.com/user-attachments/assets/520d779c-2164-4ed4-8ca5-03be9e5bfd7e" />
<img width="402" alt="image" src="https://github.com/user-attachments/assets/cb33f06c-a3b1-4cce-8344-946962520561" />
<img width="415" alt="image" src="https://github.com/user-attachments/assets/91c8fa4e-093d-42f7-90e4-d361bcd0f698" />



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
수정 삭제 모달을 컴포넌트화했습니다.
kebab 버튼은 포함하지 않았기 때문에 수정 삭제 모달을 사용하려는 페이지에서 직접 만들어주어야 합니다!!
(SollectDetailHeader.tsx 참고)

코드가 꼬이는 게 있어서 안 했는데 나중에 컴포넌트에 kebab 버튼까지 포함해서 리팩토링해보고 싶네요..



<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

