### PR TITLE
Feat/#188 쏠루트 추가된 장소 띄우기

### DIFF
--- a/src/components/Solroute/SolrouteMap.tsx
+++ b/src/components/Solroute/SolrouteMap.tsx
@@ -22,10 +22,10 @@ const SolrouteMap: React.FC = () => {
     })
   );
 
-  const { placeCoords, nextMarkers, prevMarkers, setMarkers } =
+  const { placeInfos, nextMarkers, prevMarkers, setMarkers } =
     useSolrouteWriteStore(
       useShallow((state) => ({
-        placeCoords: state.placeCoords,
+        placeInfos: state.placeInfos,
         nextMarkers: state.nextMarkers,
         prevMarkers: state.prevMarkers,
         setMarkers: state.setMarkers,
@@ -58,7 +58,7 @@ const SolrouteMap: React.FC = () => {
     if (!mapInstance.current) return;
 
     // 마커 객체 생성 및 아이콘 지정
-    const { objectList } = createMarkerObjectList(placeCoords);
+    const { objectList } = createMarkerObjectList(placeInfos);
     objectList.forEach((v, i) => {
       v.setIcon({
         url: SolrouteNums26, // png 파일
@@ -79,7 +79,7 @@ const SolrouteMap: React.FC = () => {
       bottom: 24,
       left: 24,
     });
-  }, [placeCoords]);
+  }, [placeInfos]);
 
   /* [useEffect] 마커 삭제 */
   useEffect(() => {
@@ -97,7 +97,7 @@ const SolrouteMap: React.FC = () => {
 
     // 폴리라인 추가
     const path = polyline.current.getPath();
-    placeCoords.forEach((coord) => {
+    placeInfos.forEach((coord) => {
       path.push(new naver.maps.LatLng(coord.latitude, coord.longitude));
     });
   }, [nextMarkers]);

--- a/src/components/Solroute/SolroutePlace.tsx
+++ b/src/components/Solroute/SolroutePlace.tsx
@@ -6,12 +6,17 @@ import { SolroutePlacePreview } from '../../types';
 import useDebounce from '../../hooks/useDebounce';
 import { useSolrouteWriteStore } from '../../store/solrouteWriteStore';
 import { useShallow } from 'zustand/shallow';
+import { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 
 interface SolroutePlaceProps {
   place: SolroutePlacePreview;
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
 }
 
-const SolroutePlace: React.FC<SolroutePlaceProps> = ({ place }) => {
+const SolroutePlace: React.FC<SolroutePlaceProps> = ({
+  place,
+  dragHandleProps,
+}) => {
   const lineColumnRef = useRef<HTMLDivElement | null>(null);
   const infoColumnRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -64,7 +69,9 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({ place }) => {
           ref={lineColumnRef}
           className='flex w-9 flex-col justify-start items-center gap-4 self-stretch'>
           <img src={'/solroute-dash-top-num.svg'} alt='solroute-dash-top-num' />
-          <div className='flex w-24 h-24 flex-col justify-center items-center gap-10 aspect-square'>
+          <div
+            {...dragHandleProps}
+            className='flex w-24 h-24 flex-col justify-center items-center gap-10 aspect-square'>
             <DragAndDropLine />
           </div>
           <div className='min-h-90 flex flex-col justify-start items-center self-stretch grow '>

--- a/src/components/Solroute/SolroutePlace.tsx
+++ b/src/components/Solroute/SolroutePlace.tsx
@@ -2,16 +2,34 @@ import { useEffect, useRef, useState } from 'react';
 import DragAndDropLine from '../../assets/dragAndDropLine.svg?react';
 import Trash from '../../assets/trash.svg?react';
 import { useAutoResizeAndScroll } from '../../hooks/useAutoResizeAndScroll';
+import { SolroutePlacePreview } from '../../types';
+import useDebounce from '../../hooks/useDebounce';
+import { useSolrouteWriteStore } from '../../store/solrouteWriteStore';
+import { useShallow } from 'zustand/shallow';
 
-const SolroutePlace = () => {
+interface SolroutePlaceProps {
+  place: SolroutePlacePreview;
+}
+
+const SolroutePlace: React.FC<SolroutePlaceProps> = ({ place }) => {
   const lineColumnRef = useRef<HTMLDivElement | null>(null);
   const infoColumnRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const [memo, setMemo] = useState('');
-
+  const [memo, setMemo] = useState(place.memo);
+  const debouncedMemo = useDebounce(memo, 300);
   useAutoResizeAndScroll(textareaRef);
+
+  const { setPlaceMemo } = useSolrouteWriteStore(
+    useShallow((state) => ({
+      setPlaceMemo: state.setPlaceMemo,
+    }))
+  );
+
+  useEffect(() => {
+    setPlaceMemo(place.id, memo);
+  }, [debouncedMemo, memo, place.id, setPlaceMemo]);
 
   useEffect(() => {
     const lineElement = lineColumnRef.current;
@@ -68,14 +86,14 @@ const SolroutePlace = () => {
             <div className='flex flex-col items-start gap-2 grow'>
               <div className='flex justify-center items-center gap-8'>
                 <div className='text-primary-950 text-center text-base not-italic font-bold leading-24 tracking-tight'>
-                  성수까망
+                  {place.name}
                 </div>
                 <div className='text-primary-400 text-xs not-italic font-normal leading-18 tracking-[-0.18px]'>
-                  카페
+                  {place.detailedCategory}
                 </div>
               </div>
               <div className='text-primary-400 text-sm not-italic font-normal leading-[120%] tracking-[-0.21px]'>
-                서울 성동구 연무장5가길 20 2층
+                {place.address}
               </div>
             </div>
             <div className='flex w-40 h-40 justify-end items-center gap-10'>

--- a/src/components/Solroute/SolroutePlace.tsx
+++ b/src/components/Solroute/SolroutePlace.tsx
@@ -21,8 +21,9 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({ place }) => {
   const debouncedMemo = useDebounce(memo, 300);
   useAutoResizeAndScroll(textareaRef);
 
-  const { setPlaceMemo } = useSolrouteWriteStore(
+  const { deletePlaceInfo, setPlaceMemo } = useSolrouteWriteStore(
     useShallow((state) => ({
+      deletePlaceInfo: state.deletePlaceInfo,
       setPlaceMemo: state.setPlaceMemo,
     }))
   );
@@ -50,6 +51,10 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({ place }) => {
       observer.disconnect();
     };
   }, [textareaRef]);
+
+  const onDeleteClick = () => {
+    deletePlaceInfo(place.id);
+  };
 
   return (
     <div ref={containerRef} className='flex items-start self-stretch'>
@@ -97,7 +102,9 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({ place }) => {
               </div>
             </div>
             <div className='flex w-40 h-40 justify-end items-center gap-10'>
-              <div className='flex p-4 items-center rounded-lg border-1 border-solid border-primary-700'>
+              <div
+                onClick={onDeleteClick}
+                className='flex p-4 items-center rounded-lg border-1 border-solid border-primary-700'>
                 <Trash className='text-primary-700' />
               </div>
             </div>

--- a/src/pages/SolrouteWritePage.tsx
+++ b/src/pages/SolrouteWritePage.tsx
@@ -4,27 +4,12 @@ import SolrouteMap from '../components/Solroute/SolrouteMap';
 import SolroutePlace from '../components/Solroute/SolroutePlace';
 import SolrouteTitle from '../components/Solroute/SolrouteTitle';
 import { useSolrouteWriteStore } from '../store/solrouteWriteStore';
-import { MarkerInfoType, SolroutePlacePreview } from '../types';
 import { useNavigate } from 'react-router-dom';
 import LargeButton from '../components/global/LargeButton';
 
-const makePlaceCoord = (
-  placeInfos: SolroutePlacePreview[]
-): MarkerInfoType[] => {
-  const dataArray: MarkerInfoType[] = [];
-  placeInfos.forEach((v) => {
-    dataArray.push({
-      id: v.id,
-      category: v.category,
-      latitude: v.latitude,
-      longitude: v.longitude,
-    });
-  });
-  return dataArray;
-};
-
 const SolrouteWritePage = () => {
   const navigate = useNavigate();
+
   const { placeInfos } = useSolrouteWriteStore(
     useShallow((state) => ({
       placeInfos: state.placeInfos,

--- a/src/pages/SolrouteWritePage.tsx
+++ b/src/pages/SolrouteWritePage.tsx
@@ -74,6 +74,7 @@ const SolrouteWritePage = () => {
                     )}
                   </Draggable>
                 ))}
+                {provided.placeholder}
               </div>
             )}
           </Droppable>

--- a/src/pages/SolrouteWritePage.tsx
+++ b/src/pages/SolrouteWritePage.tsx
@@ -4,46 +4,9 @@ import SolrouteMap from '../components/Solroute/SolrouteMap';
 import SolroutePlace from '../components/Solroute/SolroutePlace';
 import SolrouteTitle from '../components/Solroute/SolrouteTitle';
 import { useSolrouteWriteStore } from '../store/solrouteWriteStore';
-import { useEffect } from 'react';
 import { MarkerInfoType, SolroutePlacePreview } from '../types';
 import { useNavigate } from 'react-router-dom';
 import LargeButton from '../components/global/LargeButton';
-
-const placeInfos: SolroutePlacePreview[] = [
-  {
-    id: 1,
-    seq: 1,
-    name: '리퍼크',
-    detailedCategory: '카페',
-    address: '서울특별시 강남구 강남대로 382 메리츠타워 1층',
-    memo: '리퍼크 메모 어쩌구',
-    category: 'cafe',
-    latitude: 37.4969474,
-    longitude: 127.0285793,
-  },
-  {
-    id: 2,
-    seq: 2,
-    name: '양궁카페 로빈훗 강남점',
-    detailedCategory: '양궁장',
-    address: '서울특별시 강남구 강남대로110길 13',
-    memo: ' 메모 어쩌구',
-    category: 'entertainment',
-    latitude: 37.5039947,
-    longitude: 127.0259367,
-  },
-  {
-    id: 20,
-    seq: 3,
-    name: '티틸 카페+바',
-    detailedCategory: '카페',
-    address: '서울특별시 강북구 노해로 42',
-    memo: ' 메모 어쩌구',
-    category: 'cafe',
-    latitude: 37.6391587,
-    longitude: 127.0229204,
-  },
-];
 
 const makePlaceCoord = (
   placeInfos: SolroutePlacePreview[]
@@ -62,21 +25,12 @@ const makePlaceCoord = (
 
 const SolrouteWritePage = () => {
   const navigate = useNavigate();
-  const { setPlaceInfos, setPlaceCoords } = useSolrouteWriteStore(
+  const { placeInfos } = useSolrouteWriteStore(
     useShallow((state) => ({
-      setPlaceInfos: state.setPlaceInfos,
-      setPlaceCoords: state.setPlaceCoords,
+      placeInfos: state.placeInfos,
     }))
   );
 
-  // 쏠루트 코스 상세조회 api로 데이터 받아 왔을 때
-  useEffect(() => {
-    setPlaceInfos(placeInfos);
-    setPlaceCoords(makePlaceCoord(placeInfos));
-  }, []);
-
-  const examples = [0, 1, 2, 3, 4, 5];
-  
   return (
     <div className='w-full h-full flex flex-col relative overflow-hidden'>
       <div className='fixed top-0 left-0 right-0 z-10 '>
@@ -92,15 +46,20 @@ const SolrouteWritePage = () => {
         <SolrouteMap />
         <div className='flex pt-24 pb-8 pl-16 items-center gap-10 self-stretch'>
           <p className='text-primary-950 text-sm not-italic font-normal leading-[150%] tracking-[-0.35px]'>
-            장소 {examples.length}개
+            장소 {placeInfos.length}개
           </p>
         </div>
-        {examples.map((e) => {
-          return <SolroutePlace key={e} />;
+        {placeInfos.map((place) => {
+          return <SolroutePlace key={place.id} place={place} />;
         })}
         <div className='pt-24 pb-48 px-16'>
           {/* TODD:: solmark 페이지로 이동 */}
-          <LargeButton text='장소 추가' onClick={() => {navigate('/solroute/write/search')}} />
+          <LargeButton
+            text='장소 추가'
+            onClick={() => {
+              navigate('/solroute/write/search');
+            }}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/SolrouteWritePage.tsx
+++ b/src/pages/SolrouteWritePage.tsx
@@ -64,11 +64,12 @@ const SolrouteWritePage = () => {
                     index={i}
                     key={place.id}>
                     {(provided) => (
-                      <div
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        ref={provided.innerRef}>
-                        <SolroutePlace place={place} key={place.id} />
+                      <div {...provided.draggableProps} ref={provided.innerRef}>
+                        <SolroutePlace
+                          place={place}
+                          key={place.id}
+                          dragHandleProps={provided.dragHandleProps}
+                        />
                       </div>
                     )}
                   </Draggable>

--- a/src/pages/SolrouteWritePage.tsx
+++ b/src/pages/SolrouteWritePage.tsx
@@ -6,15 +6,32 @@ import SolrouteTitle from '../components/Solroute/SolrouteTitle';
 import { useSolrouteWriteStore } from '../store/solrouteWriteStore';
 import { useNavigate } from 'react-router-dom';
 import LargeButton from '../components/global/LargeButton';
+import {
+  DragDropContext,
+  Draggable,
+  Droppable,
+  DropResult,
+} from '@hello-pangea/dnd';
 
 const SolrouteWritePage = () => {
   const navigate = useNavigate();
 
-  const { placeInfos } = useSolrouteWriteStore(
+  const { placeInfos, setPlaceInfos } = useSolrouteWriteStore(
     useShallow((state) => ({
       placeInfos: state.placeInfos,
+      setPlaceInfos: state.setPlaceInfos,
     }))
   );
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+
+    const items = Array.from(placeInfos);
+    const [reorderedItem] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, reorderedItem);
+
+    setPlaceInfos(items);
+  };
 
   return (
     <div className='w-full h-full flex flex-col relative overflow-hidden'>
@@ -34,9 +51,33 @@ const SolrouteWritePage = () => {
             장소 {placeInfos.length}개
           </p>
         </div>
-        {placeInfos.map((place) => {
-          return <SolroutePlace key={place.id} place={place} />;
-        })}
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId='placeList' direction='vertical'>
+            {(provided) => (
+              <div
+                className='placeList'
+                {...provided.droppableProps}
+                ref={provided.innerRef}>
+                {placeInfos.map((place, i) => (
+                  <Draggable
+                    draggableId={place.id.toString()}
+                    index={i}
+                    key={place.id}>
+                    {(provided) => (
+                      <div
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
+                        ref={provided.innerRef}>
+                        <SolroutePlace place={place} key={place.id} />
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
+
         <div className='pt-24 pb-48 px-16'>
           {/* TODD:: solmark 페이지로 이동 */}
           <LargeButton

--- a/src/store/solrouteWriteStore.ts
+++ b/src/store/solrouteWriteStore.ts
@@ -18,6 +18,7 @@ interface SolrouteWriteState {
   addPlaceCoords: (placeCoords: MarkerInfoType) => void;
   deletePlaceCoords: (ids: number) => void;
   setMarkers: (nextMarkers: naver.maps.Marker[]) => void;
+  setPlaceMemo: (id: number, str: string) => void;
   //장소 검색에서 사용하는 함수
   addPlace: (place: SolroutePlace) => void;
 }
@@ -55,6 +56,13 @@ export const useSolrouteWriteStore = create<SolrouteWriteState>((set, get) => ({
     const currentMarkers = get().nextMarkers;
     set({ prevMarkers: currentMarkers });
     set({ nextMarkers });
+  },
+  setPlaceMemo: (id: number, str: string) => {
+    set((state) => ({
+      placeInfos: state.placeInfos.map((place) =>
+        place.id === id ? { ...place, memo: str } : place
+      ),
+    }));
   },
 
   addPlace: (place) => {


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#188 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
기존의 하드코딩된 장소 정보를 삭제하고 '장소추가' 버튼을 통해 선택한 장소가 페이지에 나타나도록 했습니다.
추가된 장소의 trash 버튼을 누르면 해당 장소 정보를 Store의 placeInfo에서 삭제하도록 하여, 결과가 추가된 장소와 지도에 즉시 반영되도록 했습니다. 
SolroutePlace 컴포넌트의 line 부분을 드래그 앤 드롭으로 이동시킬 수 있으며, 결과가 추가된 장소와 지도에 즉시 반영되도록 했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![image](https://github.com/user-attachments/assets/4635fe43-61a3-4ee3-9a39-f0f6175c1c6f)
![image](https://github.com/user-attachments/assets/76730f8e-e3a4-4d55-88d4-be1cb0b5acdf)
![image](https://github.com/user-attachments/assets/626f8f2b-8709-416c-9c81-cd070488adb3)
![image](https://github.com/user-attachments/assets/5f90e427-e87f-4db8-a4f1-c981df20dfc7)


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
마지막 사진처럼 그래그 할 때 특정 영역 안으로만 움직일 수 있도록 하는 기능이 있는지 조사하고 추후 디자인 수정할 때 함께 리팩토링 하겠습니다. 

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

