### PR TITLE
Fix/#218 이미지 처리 오류 해결

### DIFF
--- a/src/components/Sollect/SollectWrite/SollectWriteImageInput.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteImageInput.tsx
@@ -4,13 +4,14 @@ import { useShallow } from 'zustand/shallow';
 import { useSollectWriteStore } from '../../../store/sollectWriteStore';
 
 const SollectWriteImageInput = () => {
-  const { paragraphs, focusTextarea, insertImageAtCaret } = useSollectWriteStore(
-    useShallow((state) => ({
-      paragraphs: state.paragraphs,
-      focusTextarea: state.focusTextarea,
-      insertImageAtCaret: state.insertImageAtCaret,
-    }))
-  );
+  const { paragraphs, focusTextarea, insertImageAtCaret } =
+    useSollectWriteStore(
+      useShallow((state) => ({
+        paragraphs: state.paragraphs,
+        focusTextarea: state.focusTextarea,
+        insertImageAtCaret: state.insertImageAtCaret,
+      }))
+    );
 
   const onFileChange = (newFiles: File[]) => {
     if (newFiles.length === 0) return;
@@ -20,17 +21,20 @@ const SollectWriteImageInput = () => {
     }
     newFiles.reverse().forEach((file) => {
       insertImageAtCaret(file, caret);
-    })
+    });
   };
 
   return (
     <div className='w-full h-44 flex items-center justify-start px-16 fixed bottom-0 border-t border-grayScale-100 bg-white'>
       <FilePicker
-        files={paragraphs.filter((p) => p.type === 'IMAGE').map((p) => p.file).filter((file): file is File => file !== undefined)}
+        files={paragraphs
+          .filter((p) => p.type === 'IMAGE')
+          .map((p) => p.file)
+          .filter((file): file is File => file !== undefined)}
         onChange={onFileChange}
         multiple={true}
         maxCount={100}
-        keepFiles={false}>
+        managedExternally={true}>
         {(open) => <AddLogo onClick={open} />}
       </FilePicker>
     </div>

--- a/src/components/global/FilePicker.tsx
+++ b/src/components/global/FilePicker.tsx
@@ -18,12 +18,16 @@ export interface FilePickerProps {
   accept?: string;
   /** 기존 file을 기억할지  */
   keepFiles?: boolean;
+  /* 외부 함수에 의해서만 파일이 관리될 경우 ex 쏠렉트*/
+  managedExternally?: boolean;
   /** 외부에서 클릭 트리거를 어떻게 그릴지 */
   children: (open: () => void) => React.ReactNode;
 }
 
 const DEFAULT_MAX_COUNT = 5;
-const MAX_FILE_SIZE: number = Number(import.meta.env.VITE_IMAGE_UPLOAD_MAX_SIZE);
+const MAX_FILE_SIZE: number = Number(
+  import.meta.env.VITE_IMAGE_UPLOAD_MAX_SIZE
+);
 
 const FilePicker: React.FC<FilePickerProps> = ({
   files,
@@ -33,6 +37,7 @@ const FilePicker: React.FC<FilePickerProps> = ({
   maxSize = MAX_FILE_SIZE,
   accept = '.png,.jpg,.jpeg',
   keepFiles = true,
+  managedExternally = false,
   children,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -46,30 +51,42 @@ const FilePicker: React.FC<FilePickerProps> = ({
     if (!selected.length) return;
 
     // 장수 제한
-    if (
-      keepFiles
-        ? files.length + selected.length > maxCount
-        : selected.length > maxCount
-    ) {
-      toast(<Warn title={`최대 ${maxCount}개까지 등록 가능해요`} />);
-      selected = selected.slice(0, maxCount - files.length);
+    if (keepFiles) {
+      if (files.length + selected.length > maxCount) {
+        toast(<Warn title={`최대 ${maxCount}개까지 등록 가능해요`} />);
+        selected = selected.slice(0, maxCount - files.length);
+      }
+    } else {
+      if (selected.length > maxCount) {
+        toast(<Warn title={`최대 ${maxCount}개까지 등록 가능해요`} />);
+        selected = selected.slice(0, maxCount); // 여기선 files.length 무시
+      }
     }
 
     // 크기 제한
+    let tooLargeFileExists = false;
+
+    //이미지 크기 큰 파일 필터링
     selected = selected.filter((file) => {
       if (file.size > maxSize) {
-        toast(
-          <Warn
-            title='해당 사진은 첨부할 수 없어요.'
-            message={`사진은 ${maxSize / 1024 / 1024}MB 이하만 첨부 가능해요.`}
-          />
-        );
+        tooLargeFileExists = true;
         return false;
       }
       return true;
     });
 
-    if (keepFiles) {
+    if (tooLargeFileExists) {
+      toast(
+        <Warn
+          title='해당 사진은 첨부할 수 없어요.'
+          message={`사진은 ${maxSize / 1024 / 1024}MB 이하만 첨부 가능해요.`}
+        />
+      );
+    }
+
+    if (managedExternally) {
+      onChange(selected);
+    } else if (keepFiles) {
       onChange([...files, ...selected]);
     } else {
       onChange(selected);

--- a/src/components/global/FilePicker.tsx
+++ b/src/components/global/FilePicker.tsx
@@ -23,7 +23,7 @@ export interface FilePickerProps {
 }
 
 const DEFAULT_MAX_COUNT = 5;
-const MAX_FILE_SIZE: number = Number(import.meta.env.VITE_MAX_FILE_SIZE);
+const MAX_FILE_SIZE: number = Number(import.meta.env.VITE_IMAGE_UPLOAD_MAX_SIZE);
 
 const FilePicker: React.FC<FilePickerProps> = ({
   files,


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#218 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
1. 이미지 파일 크기 필터링 오류
env파일과 FilePicker의 변수명이 달라서 생긴 문제.
변수명을 동일하게 변경해 해결
2. 쏠렉트 이미지 개수 문제
우선, keepfiles를 true로 안해서 toast를 못 띄움
keepfiles를 true로 변경해 toast는 잘 나타났으나 file이 중복돼 나타나는 문제가 발생
FilePicker는 keepfiles = true일 때 기존 파일과 새로 선택된 파일을 합침.
하지만 해당 기능을 쏠렉트 이미지 추가 함수에서 처리하고 있어 중복 문제가 발생함.
이에 외부 함수만을 의존하겠다는 managedExternally 필드를 추가해 해결함

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="352" alt="image" src="https://github.com/user-attachments/assets/87f36591-c1b8-4286-9e28-2e7f1dc9921b" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/d53c7c31-b858-4433-bcb8-82811144c4d5" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

