### PR TITLE
Feat/#232 쏠렉트 작성 변경된 디자인 적용

### DIFF
--- a/src/components/Sollect/SollectWrite/SollectWriteContent.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteContent.tsx
@@ -51,7 +51,7 @@ const SollectWriteContent = () => {
         ref={scrollRef}>
         <SollectWriteTitle />
         <div
-          className='flex-1 w-full pt-20 flex flex-col gap-16 pb-30'
+          className='flex-1 w-full pt-16 flex flex-col gap-16 pb-30'
           onClick={(e) => {
             if (e.target !== e.currentTarget) return; // 클릭한 영역이 빈 영역일 때만 실행
             // 빈 영역 클릭 시 새 텍스트 단락 추가

--- a/src/components/Sollect/SollectWrite/SollectWriteContent.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteContent.tsx
@@ -1,25 +1,32 @@
 import { useShallow } from 'zustand/shallow';
 
 import { useSollectWriteStore } from '../../../store/sollectWriteStore';
-import { useRef } from 'react';
+import { RefObject, useRef } from 'react';
 import SollectWriteTitle from './SollectWriteTitle';
 import SollectWriteTextarea from './SollectWriteTextarea';
 import XButton from '../../../assets/xButtonForImage.svg?react';
+import { useKeyboardAdjustment } from '../../../hooks/useKeyboardAdjustment';
 
-const SollectWriteContent = () => {
-  const { paragraphs, addTextParagraph, deleteParagraph } = useSollectWriteStore(
-    useShallow((state) => ({
-      paragraphs: state.paragraphs,
-      addTextParagraph: state.addTextParagraph,
-      addImageParagraph: state.addImageParagraph,
-      updateParagraphContent: state.updateParagraphContent,
-      deleteParagraph: state.deleteParagraph,
-      setParagraphs: state.setParagraphs,
-    }))
-  );
+const SollectWriteContent = ({
+  footerRef,
+}: {
+  footerRef: RefObject<HTMLDivElement | null>;
+}) => {
+  const { paragraphs, addTextParagraph, deleteParagraph } =
+    useSollectWriteStore(
+      useShallow((state) => ({
+        paragraphs: state.paragraphs,
+        addTextParagraph: state.addTextParagraph,
+        deleteParagraph: state.deleteParagraph,
+      }))
+    );
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+
+  //훅이 여기 있어야 키보드가 올라와있는 상태에서 이미지 추가 가능
+  useKeyboardAdjustment(footerRef);
 
   // 콜백 ref: 마지막 것만 저장
   const registerLastTextarea =
@@ -45,13 +52,14 @@ const SollectWriteContent = () => {
   };
 
   return (
-    <div className='w-full h-full flex flex-col overflow-hidden pb-45'>
+    <div
+      className='w-full h-full flex flex-col overflow-hidden mb-44'>
       <div
         className='flex flex-col h-full overflow-y-auto relative'
         ref={scrollRef}>
         <SollectWriteTitle />
         <div
-          className='flex-1 w-full pt-16 flex flex-col gap-16 pb-30'
+          className='flex-1 w-full pt-16 flex flex-col gap-16 pb-50'
           onClick={(e) => {
             if (e.target !== e.currentTarget) return; // 클릭한 영역이 빈 영역일 때만 실행
             // 빈 영역 클릭 시 새 텍스트 단락 추가
@@ -80,13 +88,14 @@ const SollectWriteContent = () => {
               />
             ) : (
               <div key={para.seq} className='w-full relative'>
-                <div className='absolute top-10 right-10'
-                onClick={() => {
-                  deleteParagraph(para.seq);
-                }}>
+                <div
+                  className='absolute top-10 right-10'
+                  onClick={() => {
+                    deleteParagraph(para.seq);
+                  }}>
                   <XButton />
                 </div>
-                <img src={para.imageUrl} className='w-full' /> 
+                <img src={para.imageUrl} className='w-full' />
               </div>
             )
           )}

--- a/src/components/Sollect/SollectWrite/SollectWriteImageInput.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteImageInput.tsx
@@ -2,30 +2,54 @@ import AddLogo from '../../../assets/photoAddIcon.svg?react';
 import FilePicker from '../../global/FilePicker';
 import { useShallow } from 'zustand/shallow';
 import { useSollectWriteStore } from '../../../store/sollectWriteStore';
+import { RefObject } from 'react';
 
-const SollectWriteImageInput = () => {
-  const { paragraphs, focusTextarea, insertImageAtCaret } =
+const SollectWriteImageInput = ({
+  footerRef,
+}: {
+  footerRef: RefObject<HTMLDivElement | null>;
+}) => {
+  // const footerRef = useRef<HTMLDivElement>(null);
+  const { paragraphs, focusTextarea, caretPosition, insertImageAtCaret } =
     useSollectWriteStore(
       useShallow((state) => ({
         paragraphs: state.paragraphs,
         focusTextarea: state.focusTextarea,
+        caretPosition: state.caretPosition,
         insertImageAtCaret: state.insertImageAtCaret,
       }))
     );
 
+
   const onFileChange = (newFiles: File[]) => {
-    if (newFiles.length === 0) return;
-    let caret = null;
-    if (focusTextarea) {
-      caret = focusTextarea.selectionStart ?? 0;
-    }
+  if (newFiles.length === 0) return;
+
+  if (focusTextarea) {
+    focusTextarea.focus(); // ensure focus
+
+    //textarea에서 저장한 caretPostion 을 이용해 사용
+    //기존 방식은 모바일에서 작동 안함
+    setTimeout(() => {
+      newFiles.reverse().forEach((file) => {
+        insertImageAtCaret(file, caretPosition);
+      });
+    }, 0);
+  } else {
+    // fallback: 그냥 맨 뒤에 삽입
     newFiles.reverse().forEach((file) => {
-      insertImageAtCaret(file, caret);
+      insertImageAtCaret(file, null);
     });
-  };
+  }
+};
 
   return (
-    <div className='w-full h-44 flex items-center justify-start px-16 fixed bottom-0 border-t border-grayScale-100 bg-white'>
+    <div
+      ref={footerRef}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+      // footer는 -translate-y-full로 설정해 footer의 top이 전체 화면 bottom 0에 위치할 경우 footer가 다 보임
+      className='w-full h-44 flex items-center justify-start px-16 fixed -translate-y-full border-t border-grayScale-100 bg-white'>
       <FilePicker
         files={paragraphs
           .filter((p) => p.type === 'IMAGE')

--- a/src/components/Sollect/SollectWrite/SollectWriteTitle.tsx
+++ b/src/components/Sollect/SollectWrite/SollectWriteTitle.tsx
@@ -56,8 +56,12 @@ const SollectWriteTitle = () => {
               : undefined,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
-            backgroundColor: thumbnail?.imageUrl ? '#18181866' : '#ECEEF2',
-          }}>
+            backgroundColor: '#ECEEF2'
+          }}
+        >
+          {thumbnail?.imageUrl && (
+            <div className="absolute inset-0 bg-black/50" />
+          )}
           {thumbnail?.imageUrl ? (
             <div
               onClick={open}

--- a/src/components/global/HeaderBothText.tsx
+++ b/src/components/global/HeaderBothText.tsx
@@ -25,7 +25,7 @@ const HeaderBothText: React.FC<HeaderBothTextProps> = ({
         className={`w-42 h-42 pr-16 inline-flex justify-end items-center ${
           validation
             ? 'text-primary-950 font-bold tracking-[-0.21px]'
-            : 'text-primary-300 font-normal tracking-[-0.35px]'
+            : 'text-primary-400 font-normal tracking-[-0.35px]'
         }`}
         onClick={onRight}>
         {rightText}

--- a/src/hooks/useKeyboardAdjustment.ts
+++ b/src/hooks/useKeyboardAdjustment.ts
@@ -1,0 +1,49 @@
+import { RefObject, useEffect, useLayoutEffect } from 'react';
+
+export const useKeyboardAdjustment = (
+  footerRef: RefObject<HTMLDivElement | null>
+) => {
+  useLayoutEffect(() => {
+    const footer = footerRef.current;
+    if (!footer || !window.visualViewport) return;
+
+    const vv = window.visualViewport;
+
+    //focus될 때 visualViewport에 맞춰 footer를 배치
+    const whenOpenKeyboard = () => {
+      footer.style.top = `${vv.height}px`;
+    };
+
+    //footer가 가장 하단으로 가게 변경
+    const whenCloseKeyboard = () => {
+      footer.style.top = `100dvh`;
+    };
+
+    document.addEventListener('focusout', whenCloseKeyboard);
+    document.addEventListener('focusin', whenOpenKeyboard);
+
+    return () => {
+      document.removeEventListener('focusout', whenCloseKeyboard);
+      document.removeEventListener('focusin', whenOpenKeyboard);
+    };
+  }, [footerRef]);
+
+  //ios key 실행시 document 올라가는 것을 강제로 내림
+  useEffect(() => {
+    const footer = footerRef.current;
+    if (!footer || !window.visualViewport) return;
+
+    const controlScroll = () => {
+      window.scrollTo(0, 1);
+      const vv = window.visualViewport;
+      if (!vv) return;
+      footer.style.top = `${vv.height}px`;
+    };
+
+    document.addEventListener('scroll', controlScroll);
+
+    return () => {
+      document.removeEventListener('scroll', controlScroll);
+    };
+  }, [footerRef]);
+};

--- a/src/pages/SollectWritePage.tsx
+++ b/src/pages/SollectWritePage.tsx
@@ -1,11 +1,15 @@
+import { useRef } from 'react';
 import SollectWriteContent from '../components/Sollect/SollectWrite/SollectWriteContent';
 import SollectWriteImageInput from '../components/Sollect/SollectWrite/SollectWriteImageInput';
 
 const SollectWritePage = () => {
+  const footerRef = useRef<HTMLDivElement>(null);
   return (
     <div className='w-full h-full flex flex-col relative overflow-hidden'>
-      <SollectWriteContent />
-      <SollectWriteImageInput />
+      <SollectWriteContent footerRef={footerRef} />
+      <div>
+        <SollectWriteImageInput footerRef={footerRef} />
+      </div>
     </div>
   );
 };

--- a/src/store/sollectWriteStore.ts
+++ b/src/store/sollectWriteStore.ts
@@ -7,6 +7,7 @@ type SollectWriteState = {
   seq: number;
   focusSeq: number | null;
   focusTextarea?: HTMLTextAreaElement | null; // 포커스된 텍스트 영역을 저장할 수 있는 속성
+  caretPosition?: number | null;
   title: string | null;
   thumbnail: Paragraph | null;
   paragraphs: Paragraph[];
@@ -19,6 +20,7 @@ type SollectWriteState = {
   deleteParagraph: (seq: number) => void;
   setParagraphs: (paragraphs: Paragraph[]) => void;
   setFocus: (seq: number, el: HTMLTextAreaElement | null) => void;
+  setCaretPosition: (caret: number) => void;
   insertImageAtCaret: (file: File, caret?: number | null) => void;
   addPlace: (place: PlaceInfo) => void; // 장소 ID 목록을 설정하는 함수
   removePlace: (id: number | null) => void; // 선택된 place 해제
@@ -105,6 +107,9 @@ export const useSollectWriteStore = create<SollectWriteState>((set) => ({
       focusSeq: seq,
       focusTextarea: el,
     })),
+
+  setCaretPosition: (caretPosition: number | null) =>
+    set(() => ({ caretPosition })),
 
   insertImageAtCaret: (file, caret = null) => {
     set((state) => {


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#232 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
* 쏠렉트 작성, 썸네일에 검정 배경 추가
* 비활성화 다음 버튼 스타일 변경
* 쏠렉트 이미지 삽입 하단 바 키보드 위로 고정(작동 잘 안됨)

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
크롬
하단바가 키보드 움직임에 따라 빠르게 반응하지만
종종 하단바가 커서를 가리는 문제
입력 완료 후 키보드 크기만큼 키운 height 감소 안함 문제가 있습니다.
https://github.com/user-attachments/assets/3f292a55-2b9d-4f7a-8099-c835390b0f8f

사파리
크롬의 문제점은 없으나
키보드가 내려갈 때 하단바가 한 박자 느리게 반응하는 문제가 있습니다.

https://github.com/user-attachments/assets/f9302b8b-7b8c-4c74-8cbc-b3d24698aff4


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
구현물이 많이 불안정합니다.
추후 개선 코드 작성하겠습니다.

구현 구조는 아래와 같습니다.
1. ios 강제 스크롤 막기 -> ios는 키보드가 올라올 때 document를 위로 올립니다. scroll을 감지해 강제로 1px 내려줘 스크롤을 막습니다.
2. document에 focus 발생시 변경된 visualViewport 에 맞춰 하단바 위치 수정함
3. document에 blur | outfocus 발생시 하단바를 화면 전체 하단에 위치
4. focus 중인 textarea는 innerHeight - visualViewport 크기 만큼 height 추가 -> 커서가 키보드에 안 가리게 하기 위해
5. focus가 해제된 textarea의 height를 정상 크기로 복구 -> 크롬에선 작동 안함


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

