### PR TITLE
Refactor/#256 검색화면 관련 수정

### DIFF
--- a/src/components/Searching/RelatedSearch.tsx
+++ b/src/components/Searching/RelatedSearch.tsx
@@ -12,10 +12,6 @@ const ResultIcon: React.FC<{
   isMarked: boolean | null;
   category: string;
 }> = ({ isMarked, category }) => {
-  const style = {
-    backgroundColor: `var(--color-chip-light-bg-${category})`,
-    color: `var(--color-chip-${category})`,
-  };
   const Icon =
     isMarked === null
       ? iconNonlabelSearch['city'] // null === 지역명
@@ -23,9 +19,7 @@ const ResultIcon: React.FC<{
         ? iconNonlabelSearch['mark'] // true === 장소 추가 O
         : iconNonlabelSearch[category]; // true === 장소 추가 X
   return (
-    <div
-      className='inline-flex p-4 items-center gap-6 rounded-sm'
-      style={style}>
+    <div>
       <Icon />
     </div>
   );

--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -2,14 +2,32 @@ import React from 'react';
 import SearchBar from './SearchBar';
 import XButton from '../XButton';
 import { useNavigate } from 'react-router-dom';
+import { useSearchStore } from '../../store/searchStore';
+import { useShallow } from 'zustand/shallow';
 
 const SearchArea: React.FC = () => {
-  // const { isFocused, setIsFocused } = useSearchStore();
   const navigate = useNavigate();
+
+  const { setInputValue, setRelatedSearchList, setRelatedSearchPlaceList } =
+    useSearchStore(
+      useShallow((state) => ({
+        setInputValue: state.setInputValue,
+        setRelatedSearchList: state.setRelatedSearchList,
+        setRelatedSearchPlaceList: state.setRelatedSearchPlaceList,
+      }))
+    );
+
+  const handleXButtonClick = () => {
+    setInputValue('');
+    setRelatedSearchList([]);
+    setRelatedSearchPlaceList([]);
+    navigate(-1);
+  };
+
   return (
     <div className='flex flex-row items-center justify-start gap-8 pt-[12px] px-[16px]'>
       <SearchBar />
-      <XButton onClickFunc={() => navigate(-1)} />
+      <XButton onClickFunc={handleXButtonClick} />
     </div>
   );
 };


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#256 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
- 쏠맵에서 연관 검색어 아이콘 중복 디자인 문제 해결
- 검색 영역 X 버튼 클릭 시 검색 상태 초기화 기능 추가

> X 버튼 클릭 시 검색 입력값, 연관 검색어, 연관 장소 리스트 초기화
> handleXButtonClick 함수 추가하여 검색 상태 클리어 후 뒤로가기 처리
> 검색 종료 시 깔끔한 상태 초기화로 사용자 경험 개선


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

