### PR TITLE
[fix/#272] 쏠루트 메모 작성 때마다 마커 리렌더링 문제 해결

### DIFF
--- a/src/components/Solroute/SolroutePlace.tsx
+++ b/src/components/Solroute/SolroutePlace.tsx
@@ -3,7 +3,7 @@ import DragAndDropLine from '../../assets/dragAndDropLine.svg?react';
 import Trash from '../../assets/trash.svg?react';
 import { useAutoResizeAndScroll } from '../../hooks/useAutoResizeAndScroll';
 import { SolroutePlacePreview } from '../../types';
-import useDebounce from '../../hooks/useDebounce';
+// import useDebounce from '../../hooks/useDebounce';
 import { useSolrouteWriteStore } from '../../store/solrouteWriteStore';
 import { useShallow } from 'zustand/shallow';
 import { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
@@ -25,7 +25,7 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({
 
   const [memo, setMemo] = useState(place.memo);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const debouncedMemo = useDebounce(memo, 300);
+  // const debouncedMemo = useDebounce(memo, 300);
   useAutoResizeAndScroll(textareaRef);
 
   const { deletePlaceInfo, setPlaceMemo } = useSolrouteWriteStore(
@@ -35,9 +35,9 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({
     }))
   );
 
-  useEffect(() => {
-    setPlaceMemo(place.id, memo);
-  }, [debouncedMemo, memo, place.id, setPlaceMemo]);
+  // useEffect(() => {
+  //   setPlaceMemo(place.id, memo);
+  // }, [debouncedMemo, memo, place.id, setPlaceMemo]);
 
   useEffect(() => {
     const lineElement = lineColumnRef.current;
@@ -69,7 +69,6 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({
           <div
             ref={lineColumnRef}
             className='flex w-9 flex-col justify-start items-center gap-4 self-stretch'>
-
             <img
               src={'/solroute-dash-top-num.svg'}
               alt='solroute-dash-top-num'
@@ -135,6 +134,9 @@ const SolroutePlace: React.FC<SolroutePlaceProps> = ({
                   placeholder='메모를 남겨보세요.'
                   rows={1}
                   maxLength={100}
+                  onBlur={() => {
+                    setPlaceMemo(place.id, memo);
+                  }}
                   className='text-primary-950 placeholder:text-secondary-500
                 focus:outline-none focus:ring-0 resize-none
                 self-stretch not-italic font-normal leading-[150%] tracking-[-0.35px]


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#272

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
메모의 onBlur를 이용해서 특정 시점에만 메모를 스토어에 저장하도록 하여 수정했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
좋은 아이디어를 주신 태호님 감사합니다. 

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

