### PR TITLE
[fix/#275] 쏠루트 장소 삭제시 지도에 마커 남아있는 오류 해결

### DIFF
--- a/src/components/Solroute/SolrouteMap.tsx
+++ b/src/components/Solroute/SolrouteMap.tsx
@@ -25,19 +25,23 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
     })
   );
 
-  const { placeInfos, nextMarkers, setMarkers } = useSolrouteWriteStore(
+  const { placeInfos, prevMarkers, setMarkers } = useSolrouteWriteStore(
     useShallow((state) => ({
       placeInfos: state.placeInfos,
-      nextMarkers: state.nextMarkers,
+      prevMarkers: state.prevMarkers,
       setMarkers: state.setMarkers,
     }))
   );
 
+  useEffect(() => {
+    console.log('placeInfos', placeInfos);
+  }, [placeInfos]);
 
   // 데이터 소스 결정: props가 있으면 props 사용, 없으면 store 사용
   const currentPlaceInfos = useMemo(() => {
     return placeInfosOnDisplay?.length ? placeInfosOnDisplay : placeInfos;
   }, [placeInfosOnDisplay, placeInfos]);
+
   // 지도 초기화
   useEffect(() => {
     if (!mapElement.current || !polyline.current) return;
@@ -63,21 +67,19 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
 
   // 마커 및 폴리라인 업데이트
   useEffect(() => {
-    if (!mapInstance.current || !currentPlaceInfos?.length) return;
-
-    // 기존 마커 삭제
-    const existingMarkers = nextMarkers;
-    existingMarkers.forEach((marker) => {
-      marker.setMap(null);
-    });
+    if (
+      !mapInstance.current
+      // || !currentPlaceInfos?.length
+    )
+      return;
 
     // 폴리라인 초기화
     polyline.current.setPath([]);
+
     // 새 마커 생성 및 추가
     const { objectList } = createMarkerObjectList(currentPlaceInfos);
     objectList.forEach((marker, index) => {
       marker.setIcon({
-
         url: SolrouteNums26, // png 파일
         size: new naver.maps.Size(26, 26), // 화면에 나타나는 마커의 크기
         anchor: naver.maps.Position.CENTER, // 마커 중심 설정
@@ -95,6 +97,7 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
     });
     polyline.current.setPath(path);
 
+    if (!currentPlaceInfos.length) return;
     // 모든 마커를 포함하는 bounds 계산 및 지도 이동
     const bounds = createMarkersBounds(objectList);
     if (bounds) {
@@ -138,6 +141,14 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
       // });
     }
   }, [currentPlaceInfos, setMarkers]);
+
+  useEffect(() => {
+    // 기존 마커 삭제
+    const existingMarkers = prevMarkers;
+    existingMarkers.forEach((marker) => {
+      marker.setMap(null);
+    });
+  }, [prevMarkers]);
 
   return (
     <>

--- a/src/store/solrouteWriteStore.ts
+++ b/src/store/solrouteWriteStore.ts
@@ -44,13 +44,13 @@ export const useSolrouteWriteStore = create<SolrouteWriteState>((set, get) => ({
     set({
       placeInfos: [...get().placeInfos, { ...place, seq, memo: '' }],
     });
-  }, 
+  },
   deletePlaceInfo: (id: number) => {
     const originInfos = get().placeInfos;
     const newInfos = originInfos.filter((v) => v.id != id);
     set({ placeInfos: newInfos });
   },
-  setMarkers: (nextMarkers: naver.maps.Marker[]) => { 
+  setMarkers: (nextMarkers: naver.maps.Marker[]) => {
     const currentMarkers = get().nextMarkers;
     set({ prevMarkers: currentMarkers });
     set({ nextMarkers });
@@ -63,5 +63,5 @@ export const useSolrouteWriteStore = create<SolrouteWriteState>((set, get) => ({
       placeInfos: [],
       nextMarkers: [],
       prevMarkers: [],
-    }), 
+    }),
 }));


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#275 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
solrouteWriteStore의 palceInfos를 인식하지 못 한게 아니라, palceInfos.length가 0일 때는 return했기 때문에 마지막 마커가 지워지지 않았던 것이었습니다.
마커 추가 및 삭제 로직을 분리하여 문제를 해결했습니다. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

