### PR TITLE
feat/#298: 프리뷰 리스트 장소 클릭시 지도 이동

### DIFF
--- a/src/components/BottomSheet/Preview/PreviewContent.tsx
+++ b/src/components/BottomSheet/Preview/PreviewContent.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import ContentTitle from '../ContentTitle';
 import ReviewRange from '../ReviewRange';
 import TagList from '../TagList';
 import PreviewPhotos from './PreviewPhotos';
 import { useNavigate } from 'react-router-dom';
 import { PreviewPlace } from '../../../types';
+import { useMarkerStore } from '../../../store/markerStore';
+import { useMapStore } from '../../../store/mapStore';
 
 interface PreviewContentProps {
   place: PreviewPlace;
@@ -12,18 +14,41 @@ interface PreviewContentProps {
 
 const PreviewContent: React.FC<PreviewContentProps> = ({ place }) => {
   const navigate = useNavigate();
+  const { markerInfos } = useMarkerStore();
+  const { fitCenterLocation } = useMapStore();
+
+  const { latitude, longitude } = useMemo(() => {
+    const info = markerInfos.find((info) => info.id === place.id);
+    return {
+      latitude: info?.latitude ?? null,
+      longitude: info?.longitude ?? null,
+    };
+  }, [markerInfos, place.id]);
 
   const handleClick = () => {
+    if (latitude === null || longitude === null) {
+      alert(
+        `장소의 좌표 정보를 불러올 수 없어 지도를 이동할 수 없습니다.\n ${latitude} ${longitude}`
+      );
+      return;
+    }
+    fitCenterLocation(latitude, longitude);
     navigate(`/map/detail/${place.id}`, { state: { from: 'preview' } });
   };
 
   return (
-    <div className='border-b border-primary-100 pt-12 button' onClick={handleClick}>
+    <div
+      className='border-b border-primary-100 pt-12 button'
+      onClick={handleClick}>
       {/* content title */}
       <ContentTitle previewPlace={place} property='preview' />
 
       {/* review range, place.rating이 Null이면 리뷰가 없다는 뜻임 */}
-      <ReviewRange rating={place.rating} recommend={place.isSoloRecommended} hasReviews={place.rating !== null} />
+      <ReviewRange
+        rating={place.rating}
+        recommend={place.isSoloRecommended}
+        hasReviews={place.rating !== null}
+      />
 
       {/* tag list */}
       <TagList tags={place.tags} />

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -53,6 +53,7 @@ const MapSheet = () => {
     setLastBounds,
     lastZoom,
     setLastZoom,
+    setMapInstance,
   } = useMapStore(
     useShallow((state) => ({
       locationAccessStatus: state.locationAccessStatus,
@@ -63,6 +64,7 @@ const MapSheet = () => {
       setLastBounds: state.setLastBounds,
       lastZoom: state.lastZoom,
       setLastZoom: state.setLastZoom,
+      setMapInstance: state.setMapInstance,
     }))
   );
   const {
@@ -108,6 +110,9 @@ const MapSheet = () => {
     );
 
     if (!map) return;
+    mapInstance.current = map;
+    setMapInstance(map);
+
     if (isSearchBounds) setIsSearchBounds(false);
 
     const idleEventListener = naver.maps.Event.addListener(map, 'idle', () => {
@@ -124,9 +129,12 @@ const MapSheet = () => {
 
     return () => {
       naver.maps.Event.removeListener(idleEventListener);
-      map.destroy();
+      if (mapInstance.current) {
+        setMapInstance(null);
+        mapInstance.current.destroy();
+      }
     };
-  }, [locationAccessStatus]);
+  }, [setMapInstance, locationAccessStatus]);
 
   /* [useEffect] markerInfos 변경될 때 */
   useEffect(() => {

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -138,22 +138,6 @@ const MapSheet = () => {
     };
   }, [setMapInstance, locationAccessStatus]);
 
-  /* [useEffect] markerInfos 변경될 때 */
-  useEffect(() => {
-    const result = createMarkerObjectList(markerInfos);
-    const { objectList, idList } = result;
-    setNewMarkerObjectList(objectList);
-    setMarkerIdList(idList);
-    if (filters.activeFilter === 'category') return;
-    const newBounds = createMarkersBounds(objectList);
-    if (!newBounds) return;
-
-    mapInstance.current?.fitBounds(newBounds, {
-      bottom: idList.length === 1 ? 3200 : 480,
-      maxZoom: 16,
-    });
-  }, [markerInfos]);
-
   /* [useEffect] prevMarkerObjectList 변경될 때 */
   useEffect(() => {
     deleteMarkers(prevMarkerObjectList);

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -54,6 +54,7 @@ const MapSheet = () => {
     lastZoom,
     setLastZoom,
     setMapInstance,
+    fitCenterLocation,
   } = useMapStore(
     useShallow((state) => ({
       locationAccessStatus: state.locationAccessStatus,
@@ -65,6 +66,7 @@ const MapSheet = () => {
       lastZoom: state.lastZoom,
       setLastZoom: state.setLastZoom,
       setMapInstance: state.setMapInstance,
+      fitCenterLocation: state.fitCenterLocation,
     }))
   );
   const {
@@ -160,7 +162,14 @@ const MapSheet = () => {
   /* [useEffect] newMarkerObjectList 변경될 때 */
   useEffect(() => {
     if (!mapInstance.current) return;
-    addMarkers(mapInstance, newMarkerObjectList, true, markerIdList, navigate);
+    addMarkers(
+      mapInstance,
+      newMarkerObjectList,
+      true,
+      markerIdList,
+      navigate,
+      fitCenterLocation
+    );
   }, [newMarkerObjectList]);
 
   /* 현재 지도 화면을 기준으로 마커 재검색 함수 */

--- a/src/components/Map/MapSheet.tsx
+++ b/src/components/Map/MapSheet.tsx
@@ -9,7 +9,6 @@ import { useMarkerStore } from '../../store/markerStore';
 import {
   addMarkers, // 마커 추가 함수
   createMarkerObjectList, // 마커를 객체로 생성 후 반환
-  createMarkersBounds, // 마커 객체 바운드 생성 후 반환 함수
   deleteMarkers, // 마커 제거 함수
   initMap, // 지도 생성
 } from '../../utils/mapFunc';
@@ -70,7 +69,6 @@ const MapSheet = () => {
     }))
   );
   const {
-    filters,
     searchByCategory,
     markerInfos,
     markerIdList,
@@ -80,7 +78,6 @@ const MapSheet = () => {
     prevMarkerObjectList,
   } = useMarkerStore(
     useShallow((state) => ({
-      filters: state.filters,
       searchByCategory: state.searchByCategory,
       markerInfos: state.markerInfos,
       markerIdList: state.markerIdList,
@@ -137,6 +134,14 @@ const MapSheet = () => {
       }
     };
   }, [setMapInstance, locationAccessStatus]);
+
+  /* [useEffect] markerInfos 변경될 때 */
+  useEffect(() => {
+    const result = createMarkerObjectList(markerInfos);
+    const { objectList, idList } = result;
+    setNewMarkerObjectList(objectList);
+    setMarkerIdList(idList);
+  }, [markerInfos]);
 
   /* [useEffect] prevMarkerObjectList 변경될 때 */
   useEffect(() => {

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -53,7 +53,7 @@ export const useMapStore = create<MapState>((set, get) => ({
     );
 
     mapInstance.fitBounds(bounds, {
-      bottom: 320,
+      bottom: 360,
       maxZoom: 18,
     });
   },

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -71,7 +71,7 @@ export const useMapStore = create<MapState>((set, get) => ({
     });
 
     mapInstance.fitBounds(bounds, {
-      bottom: markerInfos.length === 1 ? 320 : 48,
+      bottom: markerInfos.length === 1 ? 360 : 180,
       maxZoom: 16,
     });
   },

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { LatLngType } from '../types';
+import { LatLngType, MarkerInfoType } from '../types';
 
 interface MapState {
   locationAccessStatus: boolean | null;
@@ -16,9 +16,15 @@ interface MapState {
 
   lastZoom: number;
   setLastZoom: (zoom: number) => void;
+
+  mapInstance: naver.maps.Map | null;
+  setMapInstance: (map: naver.maps.Map | null) => void;
+
+  fitCenterLocation: (lat: number, lng: number) => void;
+  fitBoundsToMarkers: (markerInfos: MarkerInfoType[]) => void;
 }
 
-export const useMapStore = create<MapState>((set) => ({
+export const useMapStore = create<MapState>((set, get) => ({
   locationAccessStatus: null,
   setLocationAccessStatus: (b) => set({ locationAccessStatus: b }),
 
@@ -33,4 +39,40 @@ export const useMapStore = create<MapState>((set) => ({
 
   lastZoom: 15,
   setLastZoom: (zoom) => set({ lastZoom: zoom }),
+
+  mapInstance: null,
+  setMapInstance: (map) => set({ mapInstance: map }),
+
+  fitCenterLocation: (lat: number, lng: number) => {
+    const { mapInstance } = get();
+    if (!mapInstance) return;
+
+    const bounds = new naver.maps.LatLngBounds(
+      new naver.maps.LatLng(lat, lng),
+      new naver.maps.LatLng(lat, lng)
+    );
+
+    mapInstance.fitBounds(bounds, {
+      bottom: 320,
+      maxZoom: 18,
+    });
+  },
+
+  fitBoundsToMarkers: (markerInfos: MarkerInfoType[]) => {
+    const { mapInstance } = get();
+    if (!mapInstance || !markerInfos.length) return;
+
+    const bounds = new naver.maps.LatLngBounds(
+      new naver.maps.LatLng(0, 0),
+      new naver.maps.LatLng(0, 0)
+    );
+    markerInfos.forEach((marker) => {
+      bounds.extend(new naver.maps.LatLng(marker.latitude, marker.longitude));
+    });
+
+    mapInstance.fitBounds(bounds, {
+      bottom: markerInfos.length === 1 ? 320 : 48,
+      maxZoom: 16,
+    });
+  },
 }));

--- a/src/store/markerStore.ts
+++ b/src/store/markerStore.ts
@@ -105,7 +105,8 @@ export const useMarkerStore = create<markerState>()((set, get) => ({
   },
   getMapMarkerData: async () => {
     const { filters } = get();
-    const { lastBounds, fitBoundsToMarkers } = useMapStore.getState();
+    const { lastBounds, fitCenterLocation, fitBoundsToMarkers } =
+      useMapStore.getState();
     let newMarkerInfos: MarkerInfoType[] = [];
     try {
       switch (filters.activeFilter) {
@@ -119,6 +120,7 @@ export const useMarkerStore = create<markerState>()((set, get) => ({
           break;
         case 'search-district':
           newMarkerInfos = await getMarkersByRegion(filters.searchRegion!);
+          fitBoundsToMarkers(newMarkerInfos);
           break;
         case 'search-place':
           const data = await getPlaceDetail(filters.searchPlaceId!);
@@ -131,16 +133,17 @@ export const useMarkerStore = create<markerState>()((set, get) => ({
           if (data.place.isMarked !== undefined) {
             newMarkerInfos[0].isMarked = data.place.isMarked;
           }
+          fitCenterLocation(data.place.latitude, data.place.longitude);
           break;
         case 'search-places':
           newMarkerInfos = await getMarkersByIdList(filters.searchPlaceIdList!);
+          fitBoundsToMarkers(newMarkerInfos);
           break;
         default:
           newMarkerInfos = [];
           break;
       }
       set({ markerInfos: newMarkerInfos });
-      fitBoundsToMarkers(newMarkerInfos);
     } catch (error) {
       console.error('Failed to fetch map data:', error);
       set({ markerInfos: [] });

--- a/src/store/markerStore.ts
+++ b/src/store/markerStore.ts
@@ -105,7 +105,7 @@ export const useMarkerStore = create<markerState>()((set, get) => ({
   },
   getMapMarkerData: async () => {
     const { filters } = get();
-    const { lastBounds } = useMapStore.getState();
+    const { lastBounds, fitBoundsToMarkers } = useMapStore.getState();
     let newMarkerInfos: MarkerInfoType[] = [];
     try {
       switch (filters.activeFilter) {
@@ -140,6 +140,7 @@ export const useMarkerStore = create<markerState>()((set, get) => ({
           break;
       }
       set({ markerInfos: newMarkerInfos });
+      fitBoundsToMarkers(newMarkerInfos);
     } catch (error) {
       console.error('Failed to fetch map data:', error);
       set({ markerInfos: [] });

--- a/src/utils/mapFunc.ts
+++ b/src/utils/mapFunc.ts
@@ -266,7 +266,8 @@ export const addMarkers = (
   objectList: naver.maps.Marker[] | null,
   isClickAble: boolean = false,
   markerIdList?: number[] | null,
-  navigate?: NavigateFunction
+  navigate?: NavigateFunction,
+  fitCenterLocation?: (lat: number, lng: number) => void
 ) => {
   if (!mapRef.current || !objectList) return;
 
@@ -275,12 +276,10 @@ export const addMarkers = (
     m.setMap(mapRef.current);
 
     // 이벤트 리스너 (마커 클릭)
-    if (!isClickAble || !markerIdList || !navigate) return;
+    if (!isClickAble || !markerIdList || !navigate || !fitCenterLocation)
+      return;
     naver.maps.Event.addListener(m, 'click', () => {
-      mapRef.current?.morph(m.getPosition(), 16, {
-        duration: 1000,
-        easing: 'easeOutCubic',
-      });
+      fitCenterLocation(m.getPosition().y, m.getPosition().x);
 
       // todo : improve
       const isSame = window.location.pathname.includes(


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#298 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->

- mapStore에 지도 인스턴스 및 지도 이동 함수를 추가하였습니다.
- PreviewContent 클릭시 해당 장소의 마커로 지도가 이동합니다.
- 지도에 표시된 마커 클릭시, 해당 마커가 가운데로 오도록 수정하였습니다.
- 검색시 (연관 검색어 클릭 및 엔터 동작 등) 마커가 1개일 때도 지도 가운데로 오도록 수정하려고 했지만 같은 로직이 동일하게 작동하지 않아 추후 결과가 다르게 나오는 이유를 알아봐야할 것 같습니다. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->

https://github.com/user-attachments/assets/b8b9dcc8-58dc-4f24-8c46-65c7d0d953ee



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

