### PR TITLE
[feat/#301] useMarkerStore에서 searchByPlace를 추가하여 장소 클릭 시 마커 표시 기능 구현

### DIFF
--- a/src/components/Place/PreviewContentSummary.tsx
+++ b/src/components/Place/PreviewContentSummary.tsx
@@ -5,6 +5,7 @@ import TagList from '../BottomSheet/TagList';
 import { placeSummary, SolroutePreviewSummary } from '../../types';
 import SelectableChip from '../global/SelectableChip';
 import { useNavigate } from 'react-router-dom';
+import { useMarkerStore } from '../../store/markerStore';
 
 interface SummaryProps {
   place: SolroutePreviewSummary | placeSummary;
@@ -20,6 +21,8 @@ const PreviewContentSummary: React.FC<SummaryProps> = ({
 }) => {
   const navigate = useNavigate();
 
+  const { searchByPlace } = useMarkerStore();
+
   if (!place) {
     return;
   }
@@ -27,8 +30,10 @@ const PreviewContentSummary: React.FC<SummaryProps> = ({
   const handleClick = () => {
     //쏠루트일 경우는 detail로 이동하지 않음
     if (isSolroute) return;
+    searchByPlace(place.id);
     navigate(`/map/detail/${place.id}`);
   };
+
   return (
     <div
       className='w-full bg-white pt-12 pb-8 border-b border-primary-100 button'


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#301 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
쏠렉트에서 상세 글 조회시 해당 글에 연결되어 있는 장소를 클릭시에, 
쏠맵에서 해당 장소의 마커를 지도에 표시하는 기능을 추가했습니다. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->

https://github.com/user-attachments/assets/0542ae10-1391-49ed-8471-0368c65bc9d5



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

