### PR TITLE
Feat/#288 accesstoken 재발급 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/navermaps": "^3.7.9",
+        "@types/node": "^24.1.0",
         "@types/qs": "^6.14.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -2144,6 +2145,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4818,6 +4829,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@types/navermaps": "^3.7.9",
+    "@types/node": "^24.1.0",
     "@types/qs": "^6.14.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -46,8 +46,9 @@ privateAxios.interceptors.response.use(
   async (error) => {
     const { config, response } = error;
     const originalRequest = config;
+    const isLoggedIn = localStorage.getItem('accessToken') !== null;
 
-    if (response?.status === 401 && !originalRequest._retry) {
+    if (isLoggedIn && response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
 
       return new Promise((resolve, reject) => {
@@ -58,7 +59,7 @@ privateAxios.interceptors.response.use(
 
           refreshAuthToken()
             .then((res) => {
-              const newToken = res.data.accessToken;
+              const newToken = res.data.data.accessToken;
               localStorage.setItem('accessToken', newToken);
 
               // 큐에 쌓인 모든 요청 다시 실행

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -31,8 +31,12 @@ let requestQueue: {
   config: any;
 }[] = [];
 
+// dev 환경에서는 baseURL을 빈 문자열로 설정해 프록시를 이용하도록 함
+// 기존에 생성한 privateAxios를 이용하면 무한 루프가 발생할 수 있으므로 새로운 axios 인스턴스를 생성
 function refreshAuthToken() {
-  return axios.post(BASE_URL + '/api/auth/reissue-token', null, {
+  const baseURL = import.meta.env.DEV ? '' : BASE_URL;
+  return axios.post('/api/auth/reissue-token', null, {
+    baseURL,
     withCredentials: true,
   });
 }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { BASE_URL } from './urls';
+import authStore from '../store/authStore';
 
 // 인증 필요 x
 export const publicAxios = axios.create({
@@ -46,7 +47,7 @@ privateAxios.interceptors.response.use(
   async (error) => {
     const { config, response } = error;
     const originalRequest = config;
-    const isLoggedIn = localStorage.getItem('accessToken') !== null;
+    const isLoggedIn = authStore.getState().isLoggedIn;
 
     if (isLoggedIn && response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;

--- a/src/auth/OAuthCallback.tsx
+++ b/src/auth/OAuthCallback.tsx
@@ -5,6 +5,7 @@ import { useShallow } from 'zustand/shallow';
 import useLocationStore from '../store/locationStore';
 import { publicAxios } from '../api/axios';
 import { ENDPOINT } from '../api/urls';
+import axios from 'axios';
 
 const OAuthCallback = () => {
   const { search } = useLocation();
@@ -36,7 +37,10 @@ const OAuthCallback = () => {
       return;
     }
 
-    publicAxios
+    //dev 환경에서는 baseURL을 빈 문자열로 설정해 프록시를 이용하도록 함
+    const client = import.meta.env.DEV ? axios : publicAxios;
+
+    client
       .get(ENDPOINT.OAUTH_CALLBACK(loginType.toUpperCase()), {
         params: { code },
       })

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,9 +3,16 @@ import { useNavigate } from 'react-router-dom';
 import loginBackground from '../assets/loginBackground.jpg';
 import Logo from '../assets/SolepliLogoLogin.svg?react';
 import LoginButtons from '../auth/LoginButtons';
+import { useShallow } from 'zustand/shallow';
+import useAuthStore from '../store/authStore';
 
 const Login = () => {
   const navigate = useNavigate();
+  const { logout } = useAuthStore(
+    useShallow((state) => ({
+      logout: state.logout,
+    }))
+  );
   const [showButtons, setShowButtons] = useState(false);
 
   useEffect(() => {
@@ -14,6 +21,11 @@ const Login = () => {
     }, 1000);
     return () => clearTimeout(timer);
   }, []);
+
+  const onClick = () => {
+    logout();
+    navigate('/', { replace: true });
+  };
 
   return (
     <div
@@ -34,8 +46,7 @@ const Login = () => {
           <LoginButtons />
           <div
             className='text-grayScale-400 text-xs font-medium underline leading-none text-center pt-24 button'
-            onClick={() => navigate('/', { replace: true })}
-          >
+            onClick={onClick}>
             비회원으로 이용하기
           </div>
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,24 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import tailwindcss from '@tailwindcss/vite';
 import svgr from 'vite-plugin-svgr';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss(), svgr()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'https://solepli.shop',
-        changeOrigin: true,
-        secure: false,
-        cookieDomainRewrite: {
-          '*': 'localhost',
+export default defineConfig(() => {
+  const env = loadEnv(process.cwd(), '');
+  return {
+    plugins: [react(), tailwindcss(), svgr()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true,
+          secure: false,
+          cookieDomainRewrite: {
+            '*': 'localhost',
+          },
         },
       },
     },
-  },
+  };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,16 @@ import svgr from 'vite-plugin-svgr';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), svgr()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://solepli.shop',
+        changeOrigin: true,
+        secure: false,
+        cookieDomainRewrite: {
+          '*': 'localhost',
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#288 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
* refresh toekn 재발급 기능 구현

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
현재 refresh token 구현 부분에 refresh token cookie 동시성 문제를 해결하기 위해 queue를 이용함.
다만 이는 reissue-token 요청시 서버에서 refresh token을 재발급하는 경우에만 발생하는 문제임.
현재는 reissue-token 요청시 accessToken만 재발급하므로 발생하지 않는 문제임. 즉, 오버엔지니어링...

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
* 문제 파악
 https://roronoa-jongjin.tistory.com/3
* 참고했던 구현 방법
https://medium.com/@sina.alizadeh120/repeating-failed-requests-after-token-refresh-in-axios-interceptors-for-react-js-apps-50feb54ddcbc
