### PR TITLE
[fix/#309] SolmarkChip의 props로 place.isMarked 전달

### DIFF
--- a/src/components/Place/PreviewContentSummary.tsx
+++ b/src/components/Place/PreviewContentSummary.tsx
@@ -52,7 +52,10 @@ const PreviewContentSummary: React.FC<SummaryProps> = ({
         {/* right */}
         {/* preview */}
         {!isSolroute ? (
-          <SolmarkChip placeId={place.id} isMarked={isMarked} />
+          <SolmarkChip
+            placeId={place.id}
+            isMarked={place.isMarked || isMarked}
+          />
         ) : (
           //쏠루트에서 해당 컴포넌트를 호출할 때는 항상 SolroutePreviewSummary type을 받아야 함
           <SelectableChip place={place as SolroutePreviewSummary} />


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#309 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
아래 사진의 isMarked의 boolean은 쏠루트와 쏠마크에서 PreviewContentSummary를 사용할 때 사용되는 것이고,
쏠렉트에서 PreviewContentSummary를 사용할 때는 place.isMarked의 boolean을 사용해야하더라구요. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="844" height="536" alt="image" src="https://github.com/user-attachments/assets/eb9b0706-96c0-4ec3-927e-913ef25fae54" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

