### PR TITLE
Release: 2025년 8/4 20:00 배포 (#316)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/navermaps": "^3.7.9",
+        "@types/node": "^24.1.0",
         "@types/qs": "^6.14.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -2144,6 +2145,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4818,6 +4829,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@types/navermaps": "^3.7.9",
+    "@types/node": "^24.1.0",
     "@types/qs": "^6.14.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -22,15 +22,21 @@ export const getRelatedSearchWords = async (
   }
 };
 
-export const getRelatedSearchPlaces = async (keyword: string) => {
+export const getRelatedSearchPlaces = async (
+  keyword: string,
+  userLat?: number,
+  userLng?: number
+) => {
   try {
     const res = await privateAxios.get(ENDPOINT.PLACE_SEARCH, {
       params: {
-        keyword: keyword,
+        keyword,
+        userLat,
+        userLng,
       },
     });
 
-    return res.data.data.contents;
+    return res.data.data;
   } catch (e) {
     console.error(e);
   }

--- a/src/auth/OAuthCallback.tsx
+++ b/src/auth/OAuthCallback.tsx
@@ -5,6 +5,7 @@ import { useShallow } from 'zustand/shallow';
 import useLocationStore from '../store/locationStore';
 import { publicAxios } from '../api/axios';
 import { ENDPOINT } from '../api/urls';
+import axios from 'axios';
 
 const OAuthCallback = () => {
   const { search } = useLocation();
@@ -36,7 +37,10 @@ const OAuthCallback = () => {
       return;
     }
 
-    publicAxios
+    //dev 환경에서는 baseURL을 빈 문자열로 설정해 프록시를 이용하도록 함
+    const client = import.meta.env.DEV ? axios : publicAxios;
+
+    client
       .get(ENDPOINT.OAUTH_CALLBACK(loginType.toUpperCase()), {
         params: { code },
       })

--- a/src/components/Place/PreviewContentSummary.tsx
+++ b/src/components/Place/PreviewContentSummary.tsx
@@ -52,7 +52,10 @@ const PreviewContentSummary: React.FC<SummaryProps> = ({
         {/* right */}
         {/* preview */}
         {!isSolroute ? (
-          <SolmarkChip placeId={place.id} isMarked={isMarked} />
+          <SolmarkChip
+            placeId={place.id}
+            isMarked={place.isMarked || isMarked}
+          />
         ) : (
           //쏠루트에서 해당 컴포넌트를 호출할 때는 항상 SolroutePreviewSummary type을 받아야 함
           <SelectableChip place={place as SolroutePreviewSummary} />

--- a/src/components/Searching/RelatedSearchList.tsx
+++ b/src/components/Searching/RelatedSearchList.tsx
@@ -4,10 +4,7 @@ import SearchTitle from './SearchTitle';
 import { useSearchStore } from '../../store/searchStore';
 import useDebounce from '../../hooks/useDebounce';
 import { useQuery } from '@tanstack/react-query';
-import {
-  getRelatedSearchPlaces,
-  getRelatedSearchWords,
-} from '../../api/searchApi';
+import { getRelatedSearchWords } from '../../api/searchApi';
 import { useShallow } from 'zustand/shallow';
 import { useMapStore } from '../../store/mapStore';
 
@@ -37,28 +34,11 @@ const RelatedSearchList: React.FC = () => {
     enabled: debouncedInput !== '' && !!userLatLng,
   });
 
-  // 입력값과 관련된 장소들을 RelatedSearchPlace type으로 가져옴
-  const { data: dataNoLoc, isSuccess: successNoLoc } = useQuery({
-    queryKey: ['RSList', debouncedInput],
-    queryFn: () => {
-      return getRelatedSearchPlaces(debouncedInput);
-    },
-    enabled: debouncedInput !== '' && userLatLng === null,
-  });
-
   useEffect(() => {
     if (successWithLoc) {
       setRelatedSearchList(dataWithLoc);
-    } else if (successNoLoc && dataNoLoc) {
-      setRelatedSearchList(dataNoLoc);
     }
-  }, [
-    setRelatedSearchList,
-    successWithLoc,
-    successNoLoc,
-    dataWithLoc,
-    dataNoLoc,
-  ]);
+  }, [setRelatedSearchList, successWithLoc, dataWithLoc]);
 
   return (
     <div className='flex flex-col items-start'>

--- a/src/components/Searching/RelatedSearchPlaceList.tsx
+++ b/src/components/Searching/RelatedSearchPlaceList.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getRelatedSearchPlaces } from '../../api/searchApi';
 import { useShallow } from 'zustand/shallow';
 import RelatedSearchPlace from './RelatedSearchPlace';
+import { useMapStore } from '../../store/mapStore';
 
 const RelatedSearchPlaceList: React.FC = () => {
   //search와 관련된 store
@@ -18,13 +19,18 @@ const RelatedSearchPlaceList: React.FC = () => {
       }))
     );
 
+  const { userLatLng } = useMapStore();
   const debouncedInput = useDebounce(inputValue, 500);
 
   // 입력값과 관련된 장소들을 RelatedSearchPlace type으로 가져옴
   const { data, isSuccess, error } = useQuery({
     queryKey: ['RSList', debouncedInput],
     queryFn: () => {
-      return getRelatedSearchPlaces(debouncedInput);
+      return getRelatedSearchPlaces(
+        debouncedInput,
+        userLatLng?.lat,
+        userLatLng?.lng
+      );
     },
     enabled: debouncedInput !== '',
   });

--- a/src/components/Sollect/SollectDetail/AddCourseButton.tsx
+++ b/src/components/Sollect/SollectDetail/AddCourseButton.tsx
@@ -5,41 +5,60 @@ import { SolroutePayload } from '../../../types';
 import { queryClient } from '../../../main';
 import { useSollectDetailStore } from '../../../store/sollectDetailStore';
 import LoginRequiredAction from '../../../auth/LoginRequiredAction';
-import Success from '../../global/Success';
-import { toast } from 'react-toastify';
+import { useState } from 'react';
+import Modal from '../../global/Modal';
+import { useNavigate } from 'react-router-dom';
 
 const AddCourseButton = () => {
+  const [showModal, setShowModal] = useState(false);
   const { title, placeSummaries } = useSollectDetailStore();
+  const navigate = useNavigate();
+
   const mutation = useMutation({
     mutationFn: (payload: SolroutePayload) => postSolroute(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['solroutes'] });
     },
   });
-  const clickButton = async () => {
+
+  const saveCourse = async () => {
     const payload: SolroutePayload = {
       iconId: 1,
       name: title ?? '제목 없는 쏠렉트',
       placeInfos: placeSummaries.map((place, i) => ({
         id: place.id,
-        seq: i + 1,
+        seq: i + 1, // 순서 아이콘 1부터 시작
         memo: '',
       })),
     };
-    console.log(payload);
     // add to course
     await mutation.mutateAsync(payload);
     queryClient.invalidateQueries({ queryKey: ['solroutes'] });
-    toast(<Success title='코스로 저장됐습니다.' />, { autoClose: 2000 });
+    setShowModal(true);
   };
+
   const style =
     'rounded-full border-1 border-primary-700 py-4 pr-16 pl-8 flex text-sm font-bold items-center';
   return (
-    <LoginRequiredAction onAction={clickButton}>
-      <button className={'bg-white  text-primary-700 ' + style}>
-        <img src={addBlack} alt='add' className='w-24 h-24' /> 코스로 저장
-      </button>
-    </LoginRequiredAction>
+    <>
+      <LoginRequiredAction onAction={saveCourse}>
+        <button className={'bg-white  text-primary-700 ' + style}>
+          <img src={addBlack} alt='add' className='w-24 h-24' /> 코스로 저장
+        </button>
+      </LoginRequiredAction>
+      {showModal && (
+        <Modal
+          title='코스로 저장 완료!'
+          subtitle='저장한 코스를 쏠루트에서 확인할 수 있어요'
+          leftText='쏠렉트 이어보기'
+          rightText='쏠루트 보러가기'
+          onLeftClick={() => setShowModal(false)}
+          onRightClick={() => {
+            navigate('/solroute');
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,9 +3,16 @@ import { useNavigate } from 'react-router-dom';
 import loginBackground from '../assets/loginBackground.jpg';
 import Logo from '../assets/SolepliLogoLogin.svg?react';
 import LoginButtons from '../auth/LoginButtons';
+import { useShallow } from 'zustand/shallow';
+import useAuthStore from '../store/authStore';
 
 const Login = () => {
   const navigate = useNavigate();
+  const { logout } = useAuthStore(
+    useShallow((state) => ({
+      logout: state.logout,
+    }))
+  );
   const [showButtons, setShowButtons] = useState(false);
 
   useEffect(() => {
@@ -14,6 +21,11 @@ const Login = () => {
     }, 1000);
     return () => clearTimeout(timer);
   }, []);
+
+  const onClick = () => {
+    logout();
+    navigate('/', { replace: true });
+  };
 
   return (
     <div
@@ -34,8 +46,7 @@ const Login = () => {
           <LoginButtons />
           <div
             className='text-grayScale-400 text-xs font-medium underline leading-none text-center pt-24 button'
-            onClick={() => navigate('/', { replace: true })}
-          >
+            onClick={onClick}>
             비회원으로 이용하기
           </div>
         </div>

--- a/src/pages/profile/AddPlacePage.tsx
+++ b/src/pages/profile/AddPlacePage.tsx
@@ -8,6 +8,9 @@ import LargeButton from '../../components/global/LargeButton';
 import { postPlaceRequest } from '../../api/profileApi';
 import { useInputAdjustScale } from '../../hooks/useInputAdjustScale';
 import { useAutoResizeAndScroll } from '../../hooks/useAutoResizeAndScroll';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import Success from '../../components/global/Success';
 
 const AddPlacePage = () => {
   const inputPlaceRef = useRef<HTMLInputElement | null>(null);
@@ -47,7 +50,15 @@ const AddPlacePage = () => {
     }
   };
 
-  const handleSubmit = async () => {
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: () => requestAddPlace(),
+    onSuccess: () => {
+      toast(<Success title='장소 추가 요청이 완료됐습니다' />);
+      navigate('/profile');
+    },
+  });
+
+  const requestAddPlace = async () => {
     const requestBody = {
       placeName: placeName.trim(),
       address: address.trim(),
@@ -56,7 +67,10 @@ const AddPlacePage = () => {
     };
 
     await postPlaceRequest(requestBody);
-    navigate('/profile');
+  };
+
+  const handleSubmit = async () => {
+    await mutateAsync();
   };
 
   const headerStyle = 'text-primary-950 text-sm font-bold';
@@ -149,7 +163,11 @@ const AddPlacePage = () => {
               ({note.length}/500)
             </div>
           </div>
-          <LargeButton text='전송' onClick={handleSubmit} />
+          <LargeButton
+            text={isPending ? '전송 중' : '전송'}
+            disable={isPending}
+            onClick={handleSubmit}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/profile/FeedbackPage.tsx
+++ b/src/pages/profile/FeedbackPage.tsx
@@ -4,6 +4,9 @@ import { useNavigate } from 'react-router-dom';
 import { postFeedback } from '../../api/profileApi';
 import LargeButton from '../../components/global/LargeButton';
 import { useAutoResizeAndScroll } from '../../hooks/useAutoResizeAndScroll';
+import { toast } from 'react-toastify';
+import Success from '../../components/global/Success';
+import { useMutation } from '@tanstack/react-query';
 
 const FeedbackPage = () => {
   const navigate = useNavigate();
@@ -11,9 +14,16 @@ const FeedbackPage = () => {
   const [feedback, setFeedback] = useState('');
   useAutoResizeAndScroll(textareaRef);
 
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: () => postFeedback(feedback),
+    onSuccess: () => {
+      toast(<Success title='의견 남기기 성공했습니다' />);
+      navigate('/profile');
+    },
+  });
+
   const handleSubmit = async () => {
-    await postFeedback(feedback);
-    navigate('/profile');
+    await mutateAsync();
   };
   return (
     <div className='w-full'>
@@ -43,7 +53,11 @@ const FeedbackPage = () => {
             ({feedback.length}/1000)
           </div>
         </div>
-        <LargeButton text='전송' onClick={handleSubmit} />
+        <LargeButton
+          text={isPending ? '전송 중' : '전송'}
+          disable={isPending}
+          onClick={handleSubmit}
+        />
       </div>
     </div>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,24 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import tailwindcss from '@tailwindcss/vite';
 import svgr from 'vite-plugin-svgr';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss(), svgr()],
+export default defineConfig(() => {
+  const env = loadEnv(process.cwd(), '');
+  return {
+    plugins: [react(), tailwindcss(), svgr()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true,
+          secure: false,
+          cookieDomainRewrite: {
+            '*': 'localhost',
+          },
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
* [feat/#232] 본문 pt-16 변경 및 배경 이미지에 bg-black/50 추가

* [feat/#232] 작성 전 다음 버튼 색상 primary-400으로 변경

* [feat/#232] 쏠렉트 이미지 추가 하단 바 키보드 위로 고정

현재 100% 작동하지 않음.
추후 개선 필요

* [fix/#239] 쏠루트 장소 추가 엔토 오류 수정

* [feat/#239] 장소 검색 isMarked 추가

* [feat/#239] 장소 주소명 길어져도 형태 유지

* [fix/#221] 머지 충돌 수정

* [feat/#221] 프로필 메뉴 구현

* [feat/#221] 회원 화면, 간편 로그인 버튼

* [feat/#221] 프로필 수정

* [feat/#221] 유저 정보 받아오기

* [feat/#221] 프로필 수정 구현

* [fix/#221] 쏠렉트 카테고리 검색 안되는 오류 수정

* [fix/#221] 쏠렉트 포토 너비 수정

* [feat/#221] 공지사항 페이지

* [fix/#221] 태그 헤더 임시 수정

* [feat/#221] 공지사항 페이지

* [feat/#221] 공지 디테일 조회

* [feat/#221] 의견 남기기

* [feat/#221] 장소 추가 요청

* [feat/#221] 빌드 되도록 수정

* [feat/#221] 공지사항 상세 조회 id로 반영

* [fix/#243] 쏠맵 X 버튼 navigate 프리뷰 말고는 다 맵으로 돌아가도록 수정

* [fix/#243] navigate from 전달

* [feat/#243] /는 /sollect로 redirect

* [fix/#243] 프사 rounded

* [fix/#242] 로그인 후 모달 뜨는 문제 해결

* [feat/#242] 쏠루트 로그인 모달 추가

* [feat/#245] dokcerfile 추가

* main.yml 수정

* 07/06 배포 (#196)

* [refactor/#176] sollect Store에 sollects 추가

* [refactor/#176] sollects는 store에서 꺼내 쓰도록 SollectList 수정

* [feat/#176] 관련 쏠렉트 무한 스크롤

* [refactor/#176] SollectList 사용하는 컴포넌트들 수정

* [fix/#176] SollectNoResult에서는 추천쏠렉트를 쓰기 때문에 SollectList로 recommendSollects 보내기

* [refactor/#176] 수정삭제 팝오버 리팩토링

* [feat/#176] 추천 쏠렉트 연동

* [feat/#188] 쏠루트 추가된 장소 띄우기

useSolrouteWriteStore에 저장된 placeInfos 정보를 SolroutePlace에 띄우도록 수정했습니다. 새로운 메모 입력시 placeInfos의 해당 장소 메모 필드에 저장됩니다.

* [fix/#188] placeCoords를 placeInfos로 변경

* [feat/#188] deletePlaceInfo 기능 추가 및 삭제 버튼 클릭 이벤트 처리

* [feat/#189] 드래그 앤 드롭 기능 추가 및 관련 상태 관리 구현

* [feat/#188] SolroutePlace의 DragAndDropLine를 통해서만 드래그 앤 드롭이 가능하도록 수정

* [fix/#176] 추천 쏠렉트 PrivateAxios로 받아오기

* [fix/#176] 인기 쏠렉트 privateAxios로 수정

* [fix/#176] sollectApi 모두 privateAxios로 변경

* [fix/#176] placeApi privateAxios로 수정

* [refactor/#176] 쏠마크 마이 페이지 쏠렉트 작성하기 클릭 버튼 LoginRequiredAction으로 감싸기

* [refactor/#176] 쏠마크 쏠렉트 모든 쏠렉트는 isMarked true로 변경해서 setSollects에 전달하기

* [fix/#176] useLocation으로 탭바 리렌더링

* [refactor/#176] 쏠마크 탭명 추가

* [refactor/#176] PreviewContentSummary에서 place.id로 수정

* [refactor/#176] 쏠렉트 조회 BottomBar LoginRequiredAction으로 감싸기

* [feat/#188] Droppable 컴포넌트에 placeholder 추가

hello-pangea/dnd 라이브러리에서 제공하는 {provided.placeholder}를 적용하여 드래그 전 초기 Droppable 높이를 기억하도록 함.

---------




* [refactor/#236] 솔마크 상태 변경 시 마커 상태 동기화 기능 추가

SolmarkChip에서 솔마크 상태 변경 시 useMarkerStore의 markerInfos 업데이트 markerStore에 updateMarkerIsMarked 함수 추가하여 특정 장소의 isMarked 상태 토글 마커 상태와 솔마크 상태 간 실시간 동기화 구현

* [refactor/#236] 위치 추적 로직을 앱 진입점으로 이동

위치 추적을 Solmap 컴포넌트에서 main.tsx로 이동하여 앱 시작 시 바로 실행
LocationWatcher 컴포넌트를 추가하여 전역 위치 추적 관리
위치 오류 시 alert 대신 console.error로 변경하여 사용자 경험 개선

* [refactor/#236] 위치 권한 처리 로직 개선 및 맵 초기화 시점 수정

위치 권한 상태 관리를 위한 locationAccessStatus 상태 추가
getCurrentPosition으로 위치 권한 요청 후 성공/실패 처리
위치 권한 거부 시 기본 좌표(서울 시청)로 폴백 처리
MapSheet 초기화를 위치 권한 확인 완료 후로 지연하여 안정성 개선

* [fix/#236] 오타 수정

* [refactor/#236] Permissions API 기반 위치 권한 처리 로직으로 개선

navigator.permissions API를 사용하여 위치 권한 상태 미리 확인
권한 상태별 처리 로직 개선 (granted, prompt, denied)
getCurrentPosition 대신 watchPosition을 직접 사용하여 실시간 위치 추적 geolocation.ts 파일 제거 후 main.tsx에서 직접 처리
에러 메시지 개선 및 로그 추가

* [fix/#236] lastBounds가 없어서 초기 마커 추가되지 않는 문제 해결

* [feat/#253] 쏠렉트, 리뷰 작성 페이지 이미지 삭제 아이콘 변경

* [style/#256] 연관 검색어 아이콘 수정

* [refactor/#256] 검색 영역 X 버튼 클릭 시 검색 상태 초기화 기능 추가

X 버튼 클릭 시 검색 입력값, 연관 검색어, 연관 장소 리스트 초기화
handleXButtonClick 함수 추가하여 검색 상태 클리어 후 뒤로가기 처리
검색 종료 시 깔끔한 상태 초기화로 사용자 경험 개선

* [feat/#258] 쏠마크 쏠렉트 무한스크롤

* [feat/#258] 마이쏠렉트 무한스크롤

* [feat/#258] 회원 탈퇴

* [feat/#258] 닉네임 수정 검증

* [fix/#258] 쏠렉트 리스트 스타일 수정

* [fix/#258] 쏠렉트 프사 찌그러짐 수정

* [fix/#258] Tag 스크롤 수정

* [fix/#260] 로그아웃 시 store 삭제, 캐시 삭제

* [fix/#263] 카테고리 버튼 클릭 시 마커 검색 및 상태 동기화 개선

- CategoryButton 클릭 시 이전의 MapChip 카테고리 선택 상황과 무관하게 항상 카테고리 선택되도록 수정
- CategoryButton 클릭 하여 카테고리 변경 시 마커 검색 실행하여 사용자 경험 개선
- MapSheet의 재검색 함수에서 선택된 카테고리 유지하도록 수정
- 코드 포맷팅 및 불필요한 공백 제거

* [refactor/#255] 모달 구현 방식 개선

기존 router의 state에 background를 넘겨줘 모달 배경을 처리했지만,
전역적인 처리 및 취소시 무조건 background로 가기 위해 store를 이용해 구현함

* [feat/#255] 로그인 필수 페이지 로그인 안했을 경우 /으로 redirect 구현

사용법:
로그인 필수인 페이지는 아래 Route로 감싸주면 됩니다.
<Route element={<ProtectedRoute isLoggedIn={isLoggedIn} />}> {로그인 필요한 라우터}
</Route>

* [fix/#255] login page에서 OAuth 페이지로 redirect 하기 전 / 접속하던 문제 해결

* [feat/#255] 로그인 후 토큰이 유효하지 않으면 로그인 페이지로 리다이렉트

* [feat/#255] 로그인 후 뒤로가기 두번 클릭해야하는 문제 개선

* [feat/#255] 코스로 저장 클릭시 로그인 확인 기능 추가

* [fix/#255] AppRouter conflict 해결

* [fix/#268] 쏠루트 아이콘 번호 0 부터 시작하던 문제 해결

* [fix/#268] 하단바 visualViewpoint resize event에 따라 위치 변경 함수 추가

하단바가 안 내려갈 확률 감소를 위해 하단가 위치가 변하는 트리거를 하나 더 추가함.
키보다가 올라갔다 내려갈 때마다 visualViewPoint 변경되기에 해당 코드를 추가

다만 ios는 키보드가 내려갈 때 resize 함수 호출을 안하는 문제가 있음

* [fix/#268] 쏠루트 조회 페이지 마진 변경

* [fix/#272] 쏠루트 메모 작성 때마다 마커 리렌더링 문제 해결

* [feat/#276] 아이콘 모달 선택시 모당 창 닫힘

* [fix/#275] 쏠루트 장소 삭제시 지도에 마커 남아있는 오류 해결

* [feat/#271] 위치 정보가 없어도 장소 검색 가능하도록 수정

* [fix/#274] 로딩중 텍스트 삭제

* [feat/#281] 닉네임 입력시 확대되는 문제 해결

* [feat/#284] (위치정보 비허용시) 쏠맵의 현재위치로 버튼 인터렉션 구현

* [chore/#289] GCP 배포를 위한 워크플로우 수정 및 Nginx 기본 설정 파일 삭제

* [chore/#289] 환경 변수에 VITE_CLOUDFRONT_URL 추가 및 Dockerfile 삭제

* [feat/#293] 타이틀, 카테고리 글자수 표시 변경

* [refactor/#295] 버튼에 button 클래스명 입력해서 버튼 클릭 효과 적용

* [feat/#292] 코스로 저장 성공시 토스트로 알림

* [feat/#298] mapStore에 마커 정보 처리 및 맵 인스턴스 설정 기능 추가

* [feat/#298] 지도 인스턴스 설정 및 해제 로직 추가

* [feat/#298] PreviewContent에 마커 정보 및 좌표 처리 로직 추가

* [refactor/#298] fitBounds의 bottom 값 320에서 360으로 수정

* [refactor/#298] add fitCenterLocation 파라미터를 addMarkers 함수에 추가하여 마커 클릭 시 중심 위치 조정 기능 구현

* [feat/#298] add fitCenterLocation 파라미터를 addMarkers 함수에 추가하여 마커 추가 시 중심 위치 조정 기능 구현

* [fix/#298] 쏠맵에서 장소 SolmarkChip 클릭시 지도 이동되던 오류 해결

* [fix/#298] markerInfos 변경시 로직 복구

이전에 삭제한 로직이 카테고리 버튼 선택으로 마커 필터링에 영향을 주어 다시 복구함.

* [fix/#298] fitCenterLocation을 사용하여 마커 위치 조정 기능 추가

* [feat/#301] useMarkerStore에서 searchByPlace를 추가하여 장소 클릭 시 마커 표시 기능 구현

* [refactor/#300] 쏠렉트 하단바 키보드 위에 고정

ios의 safari에선 키보드가 닫힐 때 blur 이벤트가 즉각 반응하고
chrome에선 visualViewport의 resize 이벤트가 즉각 반응함.
이를 이용해 하단바를 키보드 위에 고정시킬 수 있었음.

다만 핸드폰 성능에 따라 하단바가 키보드 위로 올라오는 속도가 다름
아이폰 12까지는 문제 없으나
아이폰 11이하부터는 delay가 있음

* [refactor/#300] 하단바 이동 속도 개선

최대한 dom을 이용해 속도를 개선함.
추후 추가적인 리팩토링 예정

* [fix/#300] relatedSearch 변경된 api 적용

추후 무한 스크롤 적용 예정

* [feat/#288] refresh token 구현 WIP

구현은 완료했으나
refreshToken이 secure와 httponly이고,
sameSite 가 strict이라 cookie를 저장 못하는 문제가 있음.

* [faet/#288] proxy 구현

baseURL 없이 바로 '/api'로 시작한다면 프록시 서버를 거쳐
서버 주소가 아닌 localhost로 변경됨

이를 통해 dev 환경일 때 refresh token의 쿠키의 domain이 달라도 localhost로 변경해 브라우저에 저장할 수 있음.

* [faet/#288] dev환경에선 refresh 관련 api를 프록시 서버로 호출함

* [refactor/#288] proxy server target 주소 env에서 받아오도록 변경

* [feat/#288] 로그인한 상태일 때만 refresh token 요청하도록 변경

* [fix/#288] 로그인 검사 로직 authStore로 변경

기존 localStorage로 로그인 여부를 검사했음.
이는 로그인한 상태인데 accessToken이 없을 경우 refreshToken을 요청하지 않는 문제가 있었음.

이에 authStore.isLoggedIn 필드를 이용해 로그인 상태를 검사해 문제를 해결함.

* [fix/#306] 장소 검색 api 변경

최근 무한 스크롤 형식으로 api가 변경됐으나
다시 기존 형식 api로 변경됨.
이 때문에 장소 검색 결과가 화면에 안 나타나는 문제가 발생함.
기존 api로 변경해 문제를 해결함

* [fix/#309] SolmarkChip의 props로 place.isMarked 전달

* [feat/#308] 장소로 저장 기획 변경 반영

장소로 저장 클릭시 쏠루트로 이동할 수 있는 모달을 띄운다.

* [feat/#312] 장소 검색시 위치 정보 추가

* [refactor/#312] RelatedSearchList에 장소 추가 로직 제거

* [feat/#314] 장소 추가 요청시 버튼 disabled

* [feat/#314] 의견 남기기 요청시 버튼 disable

* [hotfix] main branch merge conflict 해결

---------

<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->


<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

