### PR TITLE
[faet/#326] ‘완료’ 및 ‘닫기’ 버튼 제공으로 사용자 액션 명확화

### DIFF
--- a/src/components/Searching/SearchArea.tsx
+++ b/src/components/Searching/SearchArea.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import SearchBar from './SearchBar';
-import XButton from '../XButton';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSearchStore } from '../../store/searchStore';
 import { useShallow } from 'zustand/shallow';
 
 const SearchArea: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const fromPlace = location.pathname.includes('/write/search'); //sollect와 solroute 작성 중 장소 검색시 사용됨
 
   const { setInputValue, setRelatedSearchList, setRelatedSearchPlaceList } =
     useSearchStore(
@@ -17,7 +18,7 @@ const SearchArea: React.FC = () => {
       }))
     );
 
-  const handleXButtonClick = () => {
+  const handleClick = () => {
     setInputValue('');
     setRelatedSearchList([]);
     setRelatedSearchPlaceList([]);
@@ -27,7 +28,11 @@ const SearchArea: React.FC = () => {
   return (
     <div className='flex flex-row items-center justify-start gap-8 pt-[12px] px-[16px]'>
       <SearchBar />
-      <XButton onClickFunc={handleXButtonClick} />
+      <button
+        className='w-38 h-38 text-primary-950 text-sm font-medium leading-tight'
+        onClick={handleClick}>
+        {fromPlace ? '완료' : '닫기'}
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#326 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
기존 아이콘 버튼에서 ‘완료’ 및 ‘닫기’ 버튼 제공으로 사용자 액션 명확화

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="383" height="837" alt="image" src="https://github.com/user-attachments/assets/65d89c1e-336f-4633-a666-64006ce9ed84" />
<img width="383" height="833" alt="image" src="https://github.com/user-attachments/assets/102faf89-bc77-499b-8766-bfe65e6af51f" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

