### PR TITLE
Feat/#330 sollect 등록시 spinner 추가

### DIFF
--- a/src/components/BottomSheet/DetailContent.tsx
+++ b/src/components/BottomSheet/DetailContent.tsx
@@ -10,6 +10,7 @@ import arrow from '../../assets/arrow.svg';
 import { useQuery } from '@tanstack/react-query';
 import ReviewWriteTriggerEmoji from './ReviewWrite/ReviewWriteTriggerEmoji';
 import DetailContentReviewResult from './DetailContentReviewResult';
+import Loading from '../global/Loading';
 
 const NoReviewResult: React.FC = () => {
   return (
@@ -33,7 +34,7 @@ const DetailContent: React.FC = () => {
     enabled: !!placeId,
   });
 
-  const[more, setMore] = useState(false);
+  const [more, setMore] = useState(false);
 
   // complete api: 마커 클릭시 해당 장소 상세정보 호출
   // complete api: 검색 결과에서 특정 장소 클릭시 상세 정보 호출
@@ -96,6 +97,7 @@ const DetailContent: React.FC = () => {
       ) : (
         <NoReviewResult />
       )}
+      {<Loading active={isLoading} text='쏠맵 불러오는 중' />}
     </div>
   );
 };

--- a/src/components/Sollect/SollectDetail/AddCourseButton.tsx
+++ b/src/components/Sollect/SollectDetail/AddCourseButton.tsx
@@ -8,13 +8,14 @@ import LoginRequiredAction from '../../../auth/LoginRequiredAction';
 import { useState } from 'react';
 import Modal from '../../global/Modal';
 import { useNavigate } from 'react-router-dom';
+import Loading from '../../global/Loading';
 
 const AddCourseButton = () => {
   const [showModal, setShowModal] = useState(false);
   const { title, placeSummaries } = useSollectDetailStore();
   const navigate = useNavigate();
 
-  const mutation = useMutation({
+  const { mutateAsync, isPending } = useMutation({
     mutationFn: (payload: SolroutePayload) => postSolroute(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['solroutes'] });
@@ -32,7 +33,7 @@ const AddCourseButton = () => {
       })),
     };
     // add to course
-    await mutation.mutateAsync(payload);
+    await mutateAsync(payload);
     queryClient.invalidateQueries({ queryKey: ['solroutes'] });
     setShowModal(true);
   };
@@ -46,6 +47,7 @@ const AddCourseButton = () => {
           <img src={addBlack} alt='add' className='w-24 h-24' /> 코스로 저장
         </button>
       </LoginRequiredAction>
+      {<Loading active={isPending} text='코스 저장 중' />}
       {showModal && (
         <Modal
           title='코스로 저장 완료!'

--- a/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
+++ b/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
@@ -4,7 +4,7 @@ import arrowTailWhite from '../../../assets/arrowTailWhite.svg';
 import kebabWhite from '../../../assets/kebabWhite.svg';
 import kebabGray from '../../../assets/kebabGray.svg';
 
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { deleteSollect } from '../../../api/sollectApi';
 import EditDeletePopover from '../../global/EditDeletePopover';
 import { useSollectDetailStore } from '../../../store/sollectDetailStore';
@@ -14,6 +14,8 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   const navigate = useNavigate();
   const [showMenu, setShowMenu] = useState(false);
   const { sollectId } = useParams();
+  const location = useLocation();
+  const to = location.state?.to || null;
 
   // 내 글인지 확인
   const userId = localStorage.getItem('userId');
@@ -30,13 +32,21 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
     navigate('/sollect/write/');
   };
 
+  const onBackClick = () => {
+    if (to) {
+      navigate(to);
+    } else {
+      navigate(-1);
+    }
+  };
+
   return (
     <div
       className={`w-full h-50 py-4 flex justify-between items-center fixed z-70 ${isTop ? 'bg-transparent' : 'bg-white'} transition-colors duration-300`}>
       {/* 뒤로가기 */}
       <div
         className='flex w-42 h-42 justify-center items-center gap-10 shrink-0 button'
-        onClick={() => navigate(-1)}>
+        onClick={onBackClick}>
         <img
           src={isTop ? arrowTailWhite : arrowTail}
           alt='arrowTail'

--- a/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
+++ b/src/components/Sollect/SollectDetail/SollectDetailHeader.tsx
@@ -8,7 +8,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { deleteSollect } from '../../../api/sollectApi';
 import EditDeletePopover from '../../global/EditDeletePopover';
 import { useSollectDetailStore } from '../../../store/sollectDetailStore';
-import { transformSollectDetailToWrite } from '../../../utils/transformDetailToWrite';
 
 const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   const navigate = useNavigate();
@@ -28,8 +27,7 @@ const SollectDetailHeader = ({ isTop }: { isTop: boolean }) => {
   };
 
   const onEditClick = () => {
-    transformSollectDetailToWrite(Number(sollectId));
-    navigate('/sollect/write/');
+    navigate(`/sollect/write/${sollectId}`);
   };
 
   const onBackClick = () => {

--- a/src/components/Sollect/SollectPhoto.tsx
+++ b/src/components/Sollect/SollectPhoto.tsx
@@ -5,7 +5,6 @@ import SollectMark from './SollectMark';
 import kebabWhite from '../../assets/kebabWhite.svg';
 import EditDeletePopover from '../global/EditDeletePopover';
 import { deleteSollect } from '../../api/sollectApi';
-import { transformSollectDetailToWrite } from '../../utils/transformDetailToWrite';
 
 type Props = SollectPhotoProps & {
   isMine?: boolean;
@@ -29,8 +28,7 @@ const SollectPhoto: React.FC<Props> = ({ sollect, isMine, horizontal }) => {
   };
 
   const onEditClick = () => {
-    transformSollectDetailToWrite(Number(sollect.sollectId));
-    navigate('/sollect/write/');
+    navigate(`/sollect/write/${sollect.sollectId}`);
   };
 
   return (

--- a/src/components/global/Loading.tsx
+++ b/src/components/global/Loading.tsx
@@ -1,0 +1,19 @@
+import Logo from '../../assets/logo.svg?react';
+
+const Loading = ({ text }: { text: string }) => {
+  return (
+    <div className='absolute inset-0 bg-black/80 flex justify-center items-center'>
+      <div className='w-160 h-200 rounded-lg bg-white flex flex-col justify-center items-center gap-24'>
+        <Logo className='w-50 h-50 animate-breathe' />
+        <p className='text-primary-950 text-sm'>
+          <span>{text}</span>
+          <span className='animate-updown delay-0'>.</span>
+          <span className='animate-updown delay-1'>.</span>
+          <span className='animate-updown delay-2'>.</span>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/components/global/Loading.tsx
+++ b/src/components/global/Loading.tsx
@@ -1,8 +1,46 @@
+import { useEffect, useState } from 'react';
 import Logo from '../../assets/logo.svg?react';
 
-const Loading = ({ text }: { text: string }) => {
+/*
+  response가 0.5초 이내로 왔을 때 그 사이에도 Loading 컴포넌트가 나타나면 사용자가 피곤함을 느낌.
+  이를 방지하기 위해 delay를 추가함.
+  delay 이내로 response가 오면 Loading 컴포넌트가 나타나지 않음
+
+  text 뒤 자동으로 애니메이션이 추가된 ...을 붙여 진행 중임을 나타냄
+*/
+
+const Loading = ({
+  text,
+  active,
+  delayMs = 500,
+}: {
+  text: string;
+  active: boolean;
+  delayMs?: number; //delay 시간 (ms)
+}) => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    if (active) {
+      timer = setTimeout(() => {
+        setShow(true);
+      }, delayMs);
+    } else {
+      if (timer) clearTimeout(timer);
+      setShow(false);
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [active, delayMs]);
+
+  if (!show) return null;
+
   return (
-    <div className='absolute inset-0 bg-black/80 flex justify-center items-center'>
+    <div className='fixed inset-0 bg-black/80 flex justify-center items-center z-500'>
       <div className='w-160 h-200 rounded-lg bg-white flex flex-col justify-center items-center gap-24'>
         <Logo className='w-50 h-50 animate-breathe' />
         <p className='text-primary-950 text-sm'>

--- a/src/index.css
+++ b/src/index.css
@@ -168,3 +168,28 @@ button { @apply active:opacity-70 }
 .button{
   @apply active:opacity-70
 }
+
+.animate-breathe {
+  transform-box: fill-box;
+  animation:
+    breathe 1.6s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  0%, 100% { scale: 0.92; }
+  50% { scale: 1.06; }
+}
+
+.animate-updown {
+  display: inline-block;
+  animation: bounceUpDown 1s ease-in-out infinite;
+}
+
+.delay-0 { animation-delay: 0s; }
+.delay-1 { animation-delay: 0.2s; }
+.delay-2 { animation-delay: 0.4s; }
+
+@keyframes bounceUpDown {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}

--- a/src/layout/SollectWriteLayout.tsx
+++ b/src/layout/SollectWriteLayout.tsx
@@ -185,7 +185,7 @@ const SollectWriteLayout = () => {
         <Outlet /> {/* editor, place … */}
       </div>
 
-      {isPending && <Loading text='쏠렉트 등록 중' />}
+      {<Loading active={isPending} text='쏠렉트 등록 중' />}
 
       {/* modal */}
       {showDeleteModal && (

--- a/src/layout/SollectWriteLayout.tsx
+++ b/src/layout/SollectWriteLayout.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import Modal from '../components/global/Modal';
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '../main';
+import Loading from '../components/global/Loading';
 
 const SollectWriteLayout = () => {
   const { pathname } = useLocation();
@@ -182,6 +183,8 @@ const SollectWriteLayout = () => {
       <div className='flex-1 overflow-y-auto'>
         <Outlet /> {/* editor, place … */}
       </div>
+
+      {isPending && <Loading text='쏠렉트 등록 중' />}
 
       {/* modal */}
       {showDeleteModal && (

--- a/src/layout/SollectWriteLayout.tsx
+++ b/src/layout/SollectWriteLayout.tsx
@@ -28,7 +28,7 @@ const SollectWriteLayout = () => {
       }))
     );
 
-  const submitSollect = async () => {
+  const submitSollect = async (): Promise<number> => {
     // 현재 작성된 paragraphs 순서대로 seq를 재설정
     const renumberParagraphs = paragraph.map((p, index) => ({
       ...p,
@@ -48,7 +48,7 @@ const SollectWriteLayout = () => {
     console.log('Sollect ID:', res);
     if (!res) {
       toast(<Warn title='솔렉트를 등록하는데 실패했습니다.' />);
-      return;
+      throw new Error('Sollect 등록 실패');
     }
 
     // 기존 id가 있다면 id를, 없다면 응답 값을 가져와 사용
@@ -65,15 +65,16 @@ const SollectWriteLayout = () => {
       }
     });
     await postSollectUpload(sollectId, formData);
-    // Sollect 등록 후 어디로 가야할지?
+    return sollectId;
   };
 
   const { mutateAsync, isPending } = useMutation({
-    mutationFn: () => submitSollect(),
-    onSuccess: () => {
+    mutationFn: submitSollect,
+    onSuccess: (id: number) => {
       reset();
       queryClient.invalidateQueries({ queryKey: ['sollects'] });
-      navigate(`/sollect`);
+      //state값을 같이 넘겨 디테일 페이지에서 뒤로가기 클릭시 /sollect로 넘어감
+      navigate(`/sollect/${id}`, { state: { to: '/sollect' } });
     },
   });
 

--- a/src/pages/ReviewWritePage.tsx
+++ b/src/pages/ReviewWritePage.tsx
@@ -17,6 +17,7 @@ import LargeButton from '../components/global/LargeButton';
 import Modal from '../components/global/Modal';
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '../main';
+import Loading from '../components/global/Loading';
 
 const ReviewWrite: React.FC = () => {
   const navigate = useNavigate();
@@ -160,6 +161,7 @@ const ReviewWrite: React.FC = () => {
           bold={true}
         />
       </div>
+      {<Loading active={isPending} text='리뷰 작성 중' />}
       {showDeleteModal && (
         <Modal
           title='아직 작성 중인 내용이 있어요!'

--- a/src/pages/SollectDetailPage.tsx
+++ b/src/pages/SollectDetailPage.tsx
@@ -11,6 +11,7 @@ import SollectDetailBottomBar from '../components/Sollect/SollectDetail/SollectD
 import AddCourseButton from '../components/Sollect/SollectDetail/AddCourseButton';
 import PlaceSummaryList from '../components/Sollect/SollectDetail/PlaceSummaryList';
 import { placeSummary } from '../types';
+import Loading from '../components/global/Loading';
 
 const SollectDetailPage = () => {
   const { sollectId } = useParams();
@@ -25,7 +26,7 @@ const SollectDetailPage = () => {
 
   useEffect(() => {
     if (sollect.data) {
-      const sum = sollect.data.placeSummaries.map((place:RawPlace) => {
+      const sum = sollect.data.placeSummaries.map((place: RawPlace) => {
         return {
           ...place,
           // id: place.placeId,
@@ -103,6 +104,7 @@ const SollectDetailPage = () => {
           </p>
         </div>
       </div>
+      <Loading active={sollect.isLoading} text='쏠렉트 불러오는 중' />
     </div>
   );
 };
@@ -110,5 +112,5 @@ const SollectDetailPage = () => {
 export default SollectDetailPage;
 
 type RawPlace = placeSummary & {
-  placeId?:number;
-}
+  placeId?: number;
+};

--- a/src/pages/SollectWritePage.tsx
+++ b/src/pages/SollectWritePage.tsx
@@ -1,9 +1,21 @@
 import { useRef } from 'react';
 import SollectWriteContent from '../components/Sollect/SollectWrite/SollectWriteContent';
 import SollectWriteImageInput from '../components/Sollect/SollectWrite/SollectWriteImageInput';
+import { useParams } from 'react-router-dom';
+import { transformSollectDetailToWrite } from '../utils/transformDetailToWrite';
+import { useQuery } from '@tanstack/react-query';
+import Loading from '../components/global/Loading';
 
 const SollectWritePage = () => {
+  const params = useParams<{ sollectId?: string }>();
   const contentRef = useRef<HTMLDivElement | null>(null);
+
+  const { isPending } = useQuery({
+    queryKey: ['sollectDetail', params.sollectId],
+    queryFn: () => transformSollectDetailToWrite(Number(params.sollectId)),
+    enabled: !!params.sollectId, // sollectId가 있을 때만 실행
+  });
+
   //setTimeout을 이용해 항상 footer의 input Event가 먼저 반응할 수 있도록 함
   const vv = window.visualViewport;
   if (!vv) return <div>Visual viewport not supported</div>;
@@ -43,6 +55,7 @@ const SollectWritePage = () => {
     <div className='w-full h-full flex flex-col'>
       <SollectWriteContent ref={contentRef} />
       <SollectWriteImageInput />
+      {<Loading active={isPending} text='쏠렉트 불러오는 중' delayMs={100} />}
     </div>
   );
 };

--- a/src/pages/profile/AddPlacePage.tsx
+++ b/src/pages/profile/AddPlacePage.tsx
@@ -11,6 +11,7 @@ import { useAutoResizeAndScroll } from '../../hooks/useAutoResizeAndScroll';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import Success from '../../components/global/Success';
+import Loading from '../../components/global/Loading';
 
 const AddPlacePage = () => {
   const inputPlaceRef = useRef<HTMLInputElement | null>(null);
@@ -170,6 +171,7 @@ const AddPlacePage = () => {
           />
         </div>
       </div>
+      {<Loading active={isPending} text='장소 추가 요청 중' />}
     </div>
   );
 };

--- a/src/pages/profile/FeedbackPage.tsx
+++ b/src/pages/profile/FeedbackPage.tsx
@@ -7,6 +7,7 @@ import { useAutoResizeAndScroll } from '../../hooks/useAutoResizeAndScroll';
 import { toast } from 'react-toastify';
 import Success from '../../components/global/Success';
 import { useMutation } from '@tanstack/react-query';
+import Loading from '../../components/global/Loading';
 
 const FeedbackPage = () => {
   const navigate = useNavigate();
@@ -59,6 +60,7 @@ const FeedbackPage = () => {
           onClick={handleSubmit}
         />
       </div>
+      {<Loading active={isPending} text='의견 남기는 중' />}
     </div>
   );
 };

--- a/src/pages/solroute/SolrouteDetailPage.tsx
+++ b/src/pages/solroute/SolrouteDetailPage.tsx
@@ -12,6 +12,7 @@ import Kebab from '../../assets/kebabGray.svg?react';
 import { queryClient } from '../../main';
 import { useSolrouteWriteStore } from '../../store/solrouteWriteStore';
 import { useShallow } from 'zustand/shallow';
+import Loading from '../../components/global/Loading';
 
 const SolrouteDetailPage = () => {
   const navigate = useNavigate();
@@ -93,6 +94,7 @@ const SolrouteDetailPage = () => {
           <SolrouteDetailPlace place={solroutePlace} key={solroutePlace.seq} />
         ))}
       </div>
+      {<Loading active={isLoading} text='쏠루트 삭제 중' />}
     </>
   );
 };

--- a/src/pages/solroute/SolrouteWritePage.tsx
+++ b/src/pages/solroute/SolrouteWritePage.tsx
@@ -25,6 +25,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import Modal from '../../components/global/Modal';
 import { queryClient } from '../../main';
+import Loading from '../../components/global/Loading';
 
 const SolrouteWritePage = () => {
   const navigate = useNavigate();
@@ -255,6 +256,7 @@ const SolrouteWritePage = () => {
           onRightClick={handleModalRight}
         />
       )}
+      {<Loading active={editMutation.isPending || postMutation.isPending} text='쏠루트 작성 중' />}
     </div>
   );
 };

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -114,6 +114,7 @@ const AppRouter = () => {
         <Route element={<ProtectedRoute isLoggedIn={isLoggedIn} />}>
           <Route path='/sollect/write/*' element={<SollectWriteLayout />}>
             <Route index element={<SollectWritePage />} />
+            <Route path=':sollectId' element={<SollectWritePage />} />
             <Route path='place' element={<SollectWritePlacePage />} />
           </Route>
           <Route path='/sollect/write/search' element={<SearchPage />} />


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#330 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->
* Loading 컴포넌트 생성
  * delay가 있어 버튼 클릭 후 바로 Loading 컴포넌트를 호출지 않도록 함
* 생성 및 조회 등 api 호출시 delay가 있을 확률이 높은 곳에 Loading 컴포넌트 추가
* 쏠렉트 수정 데이터 fetch 리팩토링 
  * 기존에는 수정 버튼에서 데이터를 가져왔음
  * 이에 변환 함수 호출을 각 버튼마다 실행해야하는 문제 존재
  * 쏠렉트 작성 page에서 기존 쏠렉트의 데이터를 fetch하도록 변경해 문제 해결

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="387" height="842" alt="Screenshot 2025-08-14 at 8 53 22 PM" src="https://github.com/user-attachments/assets/ba27908a-48c3-4c7b-8962-ff312b57fc0e" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
Loading 컴포넌트 사용법
```javascript
{<Loading active={isPending} text='쏠렉트 불러오는 중' delayMs={100} />}
```
* `active : boolean` : 사용자가 요청한 것의 상태를 나타내는 값. 요청 완료시 상태가 변해야 함 ex) `isPending` 
* `text : string` : 로딩 화면에 나타낼 문자. 뒤에 자동으로 `...`을 추가함
* `delayMs? : number` : 요청 후 몇 ms 뒤에 Loading 컴포넌트가 나타날지 정하는 값

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
https://www.nngroup.com/articles/response-times-3-important-limits/

