### PR TITLE
[feat/#341] 쏠루트 조회 화면 지도 크기를 스크롤 상황에 따라 조정

### DIFF
--- a/src/components/Solroute/SolrouteMap.tsx
+++ b/src/components/Solroute/SolrouteMap.tsx
@@ -11,9 +11,13 @@ import { SolroutePlacePreview } from '../../types';
 
 interface SolrouteMapProps {
   placeInfosOnDisplay?: SolroutePlacePreview[];
+  mapHeight?: number;
 }
 
-const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
+const SolrouteMap: React.FC<SolrouteMapProps> = ({
+  placeInfosOnDisplay,
+  mapHeight,
+}) => {
   const mapElement = useRef<HTMLDivElement | null>(null);
   const mapInstance = useRef<naver.maps.Map | null>(null);
   const polyline = useRef<naver.maps.Polyline>(
@@ -32,10 +36,6 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
       setMarkers: state.setMarkers,
     }))
   );
-
-  useEffect(() => {
-    console.log('placeInfos', placeInfos);
-  }, [placeInfos]);
 
   // 데이터 소스 결정: props가 있으면 props 사용, 없으면 store 사용
   const currentPlaceInfos = useMemo(() => {
@@ -152,10 +152,24 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
     });
   }, [prevMarkers]);
 
+  useEffect(() => {
+    if (mapInstance.current && mapHeight) {
+      // 약간의 지연 후 autoResize 호출 (DOM 업데이트 완료 대기)
+      setTimeout(() => {
+        if (mapInstance.current) {
+          mapInstance.current.autoResize();
+        }
+      }, 10);
+    }
+  }, [mapHeight]);
+
   return (
     <>
       {mapInstance ? (
-        <div ref={mapElement} className='self-stretch h-214 bg-primary-100' />
+        <div
+          ref={mapElement}
+          className='self-stretch h-full min-h-214 bg-primary-100'
+        />
       ) : (
         <div></div>
       )}

--- a/src/components/Solroute/SolrouteMap.tsx
+++ b/src/components/Solroute/SolrouteMap.tsx
@@ -53,13 +53,15 @@ const SolrouteMap: React.FC<SolrouteMapProps> = ({ placeInfosOnDisplay }) => {
     // 폴리라인 설정
     polyline.current.setMap(map);
 
+    const polylineForCleanup = polyline.current;
+    const mapInstanceForCleanup = mapInstance.current;
+
     return () => {
-      const currentPolyline = polyline.current;
-      if (currentPolyline) {
-        currentPolyline.setMap(null);
+      if (polylineForCleanup) {
+        polylineForCleanup.setMap(null);
       }
-      if (mapInstance.current) {
-        mapInstance.current.destroy();
+      if (mapInstanceForCleanup) {
+        mapInstanceForCleanup.destroy();
         mapInstance.current = null;
       }
     };

--- a/src/pages/solroute/SolrouteDetailPage.tsx
+++ b/src/pages/solroute/SolrouteDetailPage.tsx
@@ -7,7 +7,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { deleteSolroute, fetchSolroute } from '../../api/solrouteApi';
 import { SolroutePlacePreview } from '../../types';
 import EditDeletePopover from '../../components/global/EditDeletePopover';
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Kebab from '../../assets/kebabGray.svg?react';
 import { queryClient } from '../../main';
 import { useSolrouteWriteStore } from '../../store/solrouteWriteStore';
@@ -16,8 +16,14 @@ import Loading from '../../components/global/Loading';
 
 const SolrouteDetailPage = () => {
   const navigate = useNavigate();
-  const [showMenu, setShowMenu] = useState(false);
   const { solrouteId } = useParams();
+  const [showMenu, setShowMenu] = useState(false);
+  const [topHeight, setTopHeight] = useState<number>(400);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const MIN_A_HEIGHT = 214;
+  const MAX_A_HEIGHT = 400;
 
   const { setIcon, setTitle, setPlaceInfos, reset } = useSolrouteWriteStore(
     useShallow((state) => ({
@@ -39,9 +45,101 @@ const SolrouteDetailPage = () => {
     },
   });
 
-  if (isLoading) {
-    return <></>;
-  }
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    setIsDragging(true);
+    e.preventDefault();
+  }, []);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    setIsDragging(true);
+    e.preventDefault();
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging || !containerRef.current) return;
+
+      const container = containerRef.current;
+      const rect = container.getBoundingClientRect();
+      const mouseY = e.clientY - rect.top;
+      const newTopHeight = mouseY;
+      const constrainedHeight = Math.min(
+        Math.max(newTopHeight, MIN_A_HEIGHT),
+        MAX_A_HEIGHT
+      );
+
+      setTopHeight(constrainedHeight);
+    },
+    [isDragging]
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!isDragging || !containerRef.current) return;
+
+      const container = containerRef.current;
+      const rect = container.getBoundingClientRect();
+      const touchY = e.touches[0].clientY - rect.top;
+      const newTopHeight = touchY;
+      const constrainedHeight = Math.min(
+        Math.max(newTopHeight, MIN_A_HEIGHT),
+        MAX_A_HEIGHT
+      );
+
+      setTopHeight(constrainedHeight);
+      e.preventDefault();
+    },
+    [isDragging]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.addEventListener('touchmove', handleTouchMove, {
+        passive: false,
+      });
+      document.addEventListener('touchend', handleTouchEnd);
+
+      document.body.style.cursor = 'ns-resize';
+      document.body.style.userSelect = 'none';
+      document.body.style.touchAction = 'none';
+    } else {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.body.style.touchAction = '';
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.body.style.touchAction = '';
+    };
+  }, [
+    isDragging,
+    handleMouseMove,
+    handleMouseUp,
+    handleTouchMove,
+    handleTouchEnd,
+  ]);
 
   // 쏠루트 삭제
   const funcDelete = async () => {
@@ -58,6 +156,10 @@ const SolrouteDetailPage = () => {
     setPlaceInfos(data.placeInfos);
     navigate(`/solroute/write?solrouteId=${solrouteId}`);
   };
+
+  if (isLoading) {
+    return <></>;
+  }
 
   return (
     <>
@@ -78,22 +180,41 @@ const SolrouteDetailPage = () => {
           <EditDeletePopover funcDelete={funcDelete} onEditClick={funcEdit} />
         )}
       </div>
-      <div className='mt-50'>
-        <SolrouteMap placeInfosOnDisplay={data.placeInfos} />
 
-        {/* 장소 개수 */}
-        <div className='px-16 pt-16 pb-8 flex'>
-          <div className='flex-1 text-primary-950 text-sm font-normal leading-tight start-end'>
-            장소{data.placeInfos.length}개
+      <div ref={containerRef} className='pt-50 flex flex-col h-screen'>
+        {/* 지도 컨테이너 */}
+        <div style={{ height: `${topHeight}px` }}>
+          <SolrouteMap
+            placeInfosOnDisplay={data.placeInfos}
+            mapHeight={topHeight}
+          />
+        </div>
+
+        {/* 장소 정보 컨테이너 */}
+        <div
+          className='flex flex-col grow'
+          style={{ height: `calc(100vh - ${topHeight}px)` }}
+          onMouseDown={handleMouseDown}
+          onTouchStart={handleTouchStart}>
+          <div className='px-16 pt-16 pb-8 flex'>
+            <div className='flex-1 text-primary-950 text-sm font-normal leading-tight start-end'>
+              장소{data.placeInfos.length}개
+            </div>
+            <div className='py-4'>
+              <StatusChip id={data.id} status={data.status} />
+            </div>
           </div>
-          <div className='py-4'>
-            <StatusChip id={data.id} status={data.status} />
+          <div className='flex flex-col overflow-y-auto h-fit'>
+            {data.placeInfos.map((solroutePlace: SolroutePlacePreview) => (
+              <SolrouteDetailPlace
+                place={solroutePlace}
+                key={solroutePlace.seq}
+              />
+            ))}
           </div>
         </div>
-        {data.placeInfos.map((solroutePlace: SolroutePlacePreview) => (
-          <SolrouteDetailPlace place={solroutePlace} key={solroutePlace.seq} />
-        ))}
       </div>
+
       {<Loading active={isLoading} text='쏠루트 삭제 중' />}
     </>
   );


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#341 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->

이 pull request는 `SolrouteDetailPage`에 드래그 가능한 분할 뷰를 도입하여 사용자가 지도와 장소 정보 섹션의 크기를 **대화형으로 조절**할 수 있게 합니다. 주요 변경 사항은 새로운 드래그 앤 드롭 로직, 지도의 동적 높이 관리, 그리고 더 나은 반응성을 위한 `SolrouteMap` 컴포넌트의 관련 업데이트를 포함합니다.

---

### **분할 뷰 및 드래그 크기 조절 기능**

- 사용자가 분할선(divider)을 드래그하여 지도 섹션의 높이를 조절할 수 있도록 **마우스 및 터치 이벤트 핸들러**를 구현했습니다. 이 기능은 최소/최대 높이 제약 조건을 포함하며, 드래그 중 커서 및 선택 스타일을 업데이트하여 부드러운 사용자 경험을 보장합니다.
- 분할 뷰 및 드래그 동작을 관리하기 위해 **`topHeight`, `isDragging`와 같은 상태 변수와 `containerRef`와 같은 참조(refs)를 추가**했습니다.
- 지도와 장소 정보 컨테이너가 있는 **플렉스 컬럼(flex column) 레이아웃을 사용**하도록 업데이트했습니다. 지도의 높이는 `topHeight`에 의해 동적으로 설정되고, 정보 컨테이너는 남은 공간을 채우게 됩니다.

---

### **지도 컴포넌트 반응성**

- `SolrouteMap` 컴포넌트가 **새로운 `mapHeight` prop을 받도록 수정**하고, 높이가 변경될 때마다 지도 인스턴스에 지연된 `autoResize`를 트리거하도록 했습니다. 이를 통해 사용자가 분할선을 드래그할 때 지도가 올바르게 크기를 조절하도록 보장합니다.
- 언마운트 시 오래된 참조를 방지하기 위해 `SolrouteMap`의 이펙트(effect) 내 정리 로직을 개선했습니다.

---

### **일반 개선 사항**

- **데이터 준비가 완료되기 전에 페이지가 렌더링되지 않도록** 로딩 확인 및 표시기 위치를 옮겼고, 빈 화면이 표시되도록 했습니다.
- 사용되지 않는 디버그 로깅을 제거하고 가독성을 위해 훅(hooks) 임포트를 리팩터링했습니다.

이러한 변경 사항은 지도와 장소 정보 섹션을 사용자의 상호작용에 따라 크기 조절이 가능하고 반응형으로 만들어 전반적인 사용자 경험을 향상시킵니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

현재는 화면 크기를 지도 영역과 정보 영역으로 나누어 지도 크기가 변경 될 수 있도록 해두었는데, 더 좋은 구조가 있을지 고민해봐야할 것 같아요


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

