### PR TITLE
[fix/#345] 장소 정보 컨테이너의 이벤트 핸들러 위치 변경

### DIFF
--- a/src/pages/solroute/SolrouteDetailPage.tsx
+++ b/src/pages/solroute/SolrouteDetailPage.tsx
@@ -193,10 +193,11 @@ const SolrouteDetailPage = () => {
         {/* 장소 정보 컨테이너 */}
         <div
           className='flex flex-col grow'
-          style={{ height: `calc(100vh - ${topHeight}px)` }}
-          onMouseDown={handleMouseDown}
-          onTouchStart={handleTouchStart}>
-          <div className='px-16 pt-16 pb-8 flex'>
+          style={{ height: `calc(100vh - ${topHeight}px)` }}>
+          <div
+            className='px-16 pt-16 pb-8 flex'
+            onMouseDown={handleMouseDown}
+            onTouchStart={handleTouchStart}>
             <div className='flex-1 text-primary-950 text-sm font-normal leading-tight start-end'>
               장소{data.placeInfos.length}개
             </div>


### PR DESCRIPTION
<!-- PR 제목 설정 ➡️ [type/#이슈번호] 작업내용 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->

#345 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 (간략히) 설명해주세요 -->

이 pull request는 SolrouteDetailPage 컴포넌트의 컨테이너에 사소한 UI 변경을 적용합니다. onMouseDown과 onTouchStart 이벤트 핸들러를 외부 컨테이너에서 내부 컨테이너로 이동했습니다. 이 변경은 사용자 상호작용이 UI에서 처리되는 방식에 영향을 줄 수 있습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

